### PR TITLE
Det skal ikke være mulig å sende inn en søknad 2 ganger med referens …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.mottak.api
 
 import no.nav.familie.ef.mottak.api.dto.Kvittering
 import no.nav.familie.ef.mottak.service.SøknadService
+import no.nav.familie.ef.mottak.util.getRootCause
 import no.nav.familie.kontrakter.ef.søknad.*
 import no.nav.security.token.support.core.api.Protected
 import org.slf4j.LoggerFactory
@@ -29,7 +30,7 @@ class SøknadController(val søknadService: SøknadService) {
 
         validerVedlegg(søknad.vedlegg, vedleggData)
 
-        return ResponseEntity.ok(søknadService.mottaOvergangsstønad(søknad, vedleggData))
+        return okEllerKastException { søknadService.mottaOvergangsstønad(søknad, vedleggData) }
     }
 
     @PostMapping(path = ["barnetilsyn"])
@@ -39,7 +40,7 @@ class SøknadController(val søknadService: SøknadService) {
 
         validerVedlegg(søknad.vedlegg, vedleggData)
 
-        return ResponseEntity.ok(søknadService.mottaBarnetilsyn(søknad, vedleggData))
+        return okEllerKastException { søknadService.mottaBarnetilsyn(søknad, vedleggData) }
     }
 
     @PostMapping(path = ["skolepenger"])
@@ -48,8 +49,19 @@ class SøknadController(val søknadService: SøknadService) {
         val vedleggData = vedleggData(vedleggListe)
 
         validerVedlegg(søknad.vedlegg, vedleggData)
+        return okEllerKastException { søknadService.mottaSkolepenger(søknad, vedleggData) }
+    }
 
-        return ResponseEntity.ok(søknadService.mottaSkolepenger(søknad, vedleggData))
+    private fun okEllerKastException(producer: () -> Kvittering): ResponseEntity<Kvittering> {
+        try {
+            return ResponseEntity.ok(producer.invoke())
+        } catch (e: Exception) {
+            if (e.getRootCause()?.message == no.nav.familie.ef.mottak.repository.domain.Vedlegg.UPDATE_FEILMELDING) {
+                throw ApiFeil("Det går ikke å sende inn samme vedlegg to ganger", HttpStatus.BAD_REQUEST)
+            } else {
+                throw e
+            }
+        }
     }
 
     private fun vedleggData(vedleggListe: List<MultipartFile>) =

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
@@ -2,10 +2,7 @@ package no.nav.familie.ef.mottak.repository.domain
 
 import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
 import java.util.*
-import javax.persistence.Column
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class Vedlegg(@Id
@@ -15,4 +12,14 @@ data class Vedlegg(@Id
                    val navn: String,
                    val tittel: String,
                    @Convert(converter = FileCryptoConverter::class)
-                   val innhold: Fil)
+                   val innhold: Fil) {
+
+    @PreUpdate private fun preUpdate() {
+        throw UnsupportedOperationException(UPDATE_FEILMELDING)
+    }
+
+    companion object {
+
+        const val UPDATE_FEILMELDING: String = "Det går ikke å oppdatere vedlegg";
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/util/ExceptionUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/util/ExceptionUtil.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.ef.mottak.util
+
+import org.apache.commons.lang3.exception.ExceptionUtils
+
+fun Throwable.getRootCause(): Throwable? = ExceptionUtils.getRootCause(this)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/api/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/api/SøknadControllerTest.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.ef.mottak.api
 
-import io.mockk.mockk
-import io.mockk.verify
 import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
-import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.service.Testdata.søknadBarnetilsyn
 import no.nav.familie.ef.mottak.service.Testdata.søknadOvergangsstønad
 import no.nav.familie.ef.mottak.service.Testdata.søknadSkolepenger
@@ -13,27 +10,13 @@ import no.nav.familie.kontrakter.ef.søknad.Vedlegg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.exchange
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
-import org.springframework.context.annotation.Profile
 import org.springframework.http.*
 import org.springframework.test.context.ActiveProfiles
+import java.util.*
 
-@Profile("søknad-controller-test")
-@Configuration
-@Primary
-class SøknadControllerTestConfig {
-
-    @Bean fun søknadService(): SøknadService = mockk(relaxed = true)
-}
-
-@ActiveProfiles("local", "søknad-controller-test")
+@ActiveProfiles("local")
 internal class SøknadControllerTest : IntegrasjonSpringRunnerTest() {
-
-    @Autowired lateinit var søknadService: SøknadService
 
     @BeforeEach
     fun setUp() {
@@ -42,48 +25,36 @@ internal class SøknadControllerTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `overgangsstønad ok request`() {
-        val søknad = SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg("1"), lagVedlegg("2")))
-        okSøknadMedVedleggRequest(søknad, "/api/soknad")
-        okSøknadMedVedleggRequest(søknad, "/api/soknad/overgangsstonad")
-        verify(exactly = 2) { søknadService.mottaOvergangsstønad(søknad, any()) }
+        verifySøknadMedVedleggRequest(SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg(), lagVedlegg())), "/api/soknad")
+        verifySøknadMedVedleggRequest(SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg(), lagVedlegg())),
+                                      "/api/soknad/overgangsstonad")
     }
 
     @Test
     internal fun `barnetilsyn ok request`() {
-        val søknad = SøknadMedVedlegg(søknadBarnetilsyn, listOf(lagVedlegg("1"), lagVedlegg("2")))
-        okSøknadMedVedleggRequest(søknad, "/api/soknad/barnetilsyn")
-        verify(exactly = 1) { søknadService.mottaBarnetilsyn(søknad, any()) }
+        val søknad = SøknadMedVedlegg(søknadBarnetilsyn, listOf(lagVedlegg(), lagVedlegg()))
+        verifySøknadMedVedleggRequest(søknad, "/api/soknad/barnetilsyn")
     }
 
     @Test
     internal fun `skolepenger ok request`() {
-        val søknad = SøknadMedVedlegg(søknadSkolepenger, listOf(lagVedlegg("1"), lagVedlegg("2")))
-        okSøknadMedVedleggRequest(søknad, "/api/soknad/skolepenger")
-        verify(exactly = 1) { søknadService.mottaSkolepenger(søknad, any()) }
+        val søknad = SøknadMedVedlegg(søknadSkolepenger, listOf(lagVedlegg(), lagVedlegg()))
+        verifySøknadMedVedleggRequest(søknad, "/api/soknad/skolepenger")
     }
 
-    private fun <T> okSøknadMedVedleggRequest(søknad: SøknadMedVedlegg<T>,
-                                              url: String) {
-        headers.set(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
-        val request = MultipartBuilder()
-                .withJson("søknad", søknad)
-                .withByteArray("vedlegg", "1", byteArrayOf(12))
-                .withByteArray("vedlegg", "2", byteArrayOf(12))
-                .build()
-
-        val response: ResponseEntity<Any> =
-                restTemplate.exchange(localhost(url),
-                                      HttpMethod.POST,
-                                      HttpEntity(request, headers))
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    @Test
+    internal fun `det skal ikke være mulig å sende inn samme vedlegg på nytt med ny søknad`() {
+        val vedleggId = UUID.randomUUID().toString()
+        val søknad = SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg(vedleggId)))
+        verifySøknadMedVedleggRequest(søknad, "/api/soknad/overgangsstonad")
+        verifySøknadMedVedleggRequest(søknad, "/api/soknad/overgangsstonad", HttpStatus.BAD_REQUEST)
     }
 
     @Test
     internal fun `vedlegg savnes i json`() {
         headers.set(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
         val request = MultipartBuilder()
-                .withJson("søknad", SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg("1"))))
+                .withJson("søknad", SøknadMedVedlegg(søknadOvergangsstønad, listOf(lagVedlegg())))
                 .build()
         val response: ResponseEntity<Any> =
                 restTemplate.exchange(localhost("/api/soknad"),
@@ -108,5 +79,24 @@ internal class SøknadControllerTest : IntegrasjonSpringRunnerTest() {
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
-    private fun lagVedlegg(id: String) = Vedlegg(id, "navn", "tittel")
+    private fun <T> verifySøknadMedVedleggRequest(søknad: SøknadMedVedlegg<T>,
+                                                  url: String,
+                                                  forventetHttpStatus: HttpStatus = HttpStatus.OK) {
+        headers.set(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+        val multipartBuilder = MultipartBuilder()
+                .withJson("søknad", søknad)
+
+        søknad.vedlegg.forEach {
+            multipartBuilder.withByteArray("vedlegg", it.id, byteArrayOf(12))
+        }
+
+        val response: ResponseEntity<Any> =
+                restTemplate.exchange(localhost(url),
+                                      HttpMethod.POST,
+                                      HttpEntity(multipartBuilder.build(), headers))
+
+        assertThat(response.statusCode).isEqualTo(forventetHttpStatus)
+    }
+
+    private fun lagVedlegg(id: String = UUID.randomUUID().toString()) = Vedlegg(id, "navn", "tittel")
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,4 +6,5 @@
               value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
+    <logger name="org.apache.kafka.clients" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
…til samme vedlegg

Når man har sendt inn en soknad er det mulig å gå tilbake i historikken i nettleseren
Då er det mulig å trykke på send inn på nytt.

Idag gjenbruker vi ID's fra familie-dokument.
Alternativet er att vi oppretter nye id'n i soknad-api, slik at det er riktige referenser og vedlegg-id'n

