### PR TITLE
Skal kun opprette sak for førstegangsbehandlinger for hver stønad

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SakService.kt
@@ -81,7 +81,11 @@ class SakService(private val integrasjonerClient: IntegrasjonerClient,
     private fun harBrevkode(journalpost: Journalpost, dokumentBrevkode: DokumentBrevkode): Boolean {
         return journalpost.dokumenter
                 ?.filter { dokument -> DokumentBrevkode.erGyldigBrevkode(dokument.brevkode) }
-                ?.any { DokumentBrevkode.fraBrevkode(it.brevkode) == dokumentBrevkode } ?: false
+                ?.filter { DokumentBrevkode.fraBrevkode(it.brevkode) == dokumentBrevkode }
+                ?.any {
+                    logger.info("Fant riktig brevkode=$dokumentBrevkode for journalpost=${journalpost.journalpostId} og dokument=${it.dokumentInfoId}")
+                    return true
+                }?: false
 
     }
 


### PR DESCRIPTION
Ettersom behandlingstema kun finnes på "våre" journalposter forsøker vi heller å se på brevkode i dokumentene. Her vil treffraten være vesentlig bedre for saker opprettet i perioden 2019-medio 2020. Før 2019 er det nok også litt "ymse", men ikke sikkert det er like kritisk 