### PR TITLE
Med nytt prosessering-lib er trigger_tid not null. Av den grunnen opp…

### DIFF
--- a/src/main/resources/db/migration/V13__trigger_tid_null.sql
+++ b/src/main/resources/db/migration/V13__trigger_tid_null.sql
@@ -1,0 +1,2 @@
+UPDATE task SET trigger_tid=opprettet_tid WHERE trigger_tid IS NULL;
+ALTER TABLE task ALTER COLUMN trigger_tid SET NOT NULL;


### PR DESCRIPTION
…daterer vi alle som har slik att vi ikke trenger å ha spesielle sql'er for nullable datoer

Ca 23 saker i preprod og det samme i prod.

Trigger_tid ble tidligere satt til null når en sak ble rekjørt. Nå blir den ikke endret, dvs når man rekjør så settes status kun til KLAR_TIL_PLUKK, men blir kjørt når triggertiden er riktig. 
