### PR TITLE
Bump "opprett oppgave" til v2 og bump "finn oppgaver" til v4

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapper.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 @Component
 class OpprettOppgaveMapper(private val integrasjonerClient: IntegrasjonerClient) {
 
-    fun toDto(journalpost: Journalpost) = OpprettOppgave(ident = tilOppgaveIdent(journalpost),
+    fun toDto(journalpost: Journalpost) = OpprettOppgaveRequest(ident = tilOppgaveIdent(journalpost),
                                                          saksId = null,
                                                          journalpostId = journalpost.journalpostId,
                                                          tema = Tema.ENF,
@@ -20,7 +20,7 @@ class OpprettOppgaveMapper(private val integrasjonerClient: IntegrasjonerClient)
                                                          behandlingstema = journalpost.behandlingstema,
                                                          enhetsnummer = null)
 
-    fun toBehandleSakOppgave(journalpost: Journalpost) = OpprettOppgave(ident = tilOppgaveIdent(journalpost),
+    fun toBehandleSakOppgave(journalpost: Journalpost) = OpprettOppgaveRequest(ident = tilOppgaveIdent(journalpost),
                                                          saksId = null,
                                                          tema = Tema.ENF,
                                                          oppgavetype = Oppgavetype.BehandleSak,
@@ -34,17 +34,17 @@ class OpprettOppgaveMapper(private val integrasjonerClient: IntegrasjonerClient)
         return journalpost.dokumenter!!.firstOrNull { it.brevkode != null }?.tittel
     }
 
-    private fun tilOppgaveIdent(journalpost: Journalpost): OppgaveIdent? {
+    private fun tilOppgaveIdent(journalpost: Journalpost): OppgaveIdentV2? {
         if (journalpost.bruker == null) {
             return null
         }
 
         return when (journalpost.bruker!!.type) {
             BrukerIdType.FNR -> {
-                OppgaveIdent(ident = integrasjonerClient.hentAktørId(journalpost.bruker!!.id), type = IdentType.Aktør)
+                OppgaveIdentV2(ident = integrasjonerClient.hentAktørId(journalpost.bruker!!.id), gruppe = IdentGruppe.AKTOERID)
             }
-            BrukerIdType.ORGNR -> OppgaveIdent(ident = journalpost.bruker!!.id, type = IdentType.Organisasjon)
-            BrukerIdType.AKTOERID -> OppgaveIdent(ident = journalpost.bruker!!.id, type = IdentType.Aktør)
+            BrukerIdType.ORGNR -> OppgaveIdentV2(ident = journalpost.bruker!!.id, gruppe = IdentGruppe.ORGNR)
+            BrukerIdType.AKTOERID -> OppgaveIdentV2(ident = journalpost.bruker!!.id, gruppe = IdentGruppe.AKTOERID)
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
@@ -9,7 +9,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
-import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgave
+import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -42,7 +42,7 @@ class MockConfiguration {
             return ArkiverDokumentResponse("journalpostId1", true)
         }
 
-        override fun lagOppgave(opprettOppgave: OpprettOppgave): OppgaveResponse {
+        override fun lagOppgave(opprettOppgaveRequest: OpprettOppgaveRequest): OppgaveResponse {
             return OppgaveResponse(1)
         }
 


### PR DESCRIPTION
Bumper opprett oppgave til v4 og opprett oppgave til v2, så vi kan fjerne disse endepunktene i familie-integrasjoner.

"finn oppgaver" har blitt en post, men request / response er likt.
"opprett oppgave" har ny request: OpprettOppgaveRequest.

ferdigstilling benyttet "opprett oppgave"-path, må bruke sin egen etter endring av path.

Fant noen funksjoner i IntegrasjonerClient uten parametre - disse er gjort om til verdier på lik linje med de andre.