### PR TITLE
Kaster rekjørSenereException som håndteres av prosesseringrammeverket…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <springfox.version>3.0.0</springfox.version>
         <mockk.version>1.10.5</mockk.version>
         <felles.version>1.20210121113106_ca34836</felles.version>
-        <prosessering.version>1.20210121125305_8a8a53b</prosessering.version>
+        <prosessering.version>1.20210219072056_4474948</prosessering.version>
         <confluent.version>6.0.1</confluent.version>
         <kontrakter.version>2.0_20210202123904_e91b7d1</kontrakter.version>
         <brukernotifikasjon-skjemas.version>1.2020.11.16-15.17-5f7495d2ba72</brukernotifikasjon-skjemas.version>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
@@ -8,6 +8,7 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.error.RekjørSenereException
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -39,8 +40,7 @@ class OpprettSakTask(private val taskRepository: TaskRepository,
             opprettNesteTask(task, soknadMedSaksnummer)
         } catch (e: Exception) {
             if (erKlokkenMellom21Og06()) {
-                logger.info("Oppretter en ny task som kjører kl 06 id=${task.id} callId=${task.callId}")
-                taskRepository.save(Task(payload= task.payload, type = task.type, metadata = task.metadata, triggerTid = kl06IdagEllerNesteDag()))
+                throw RekjørSenereException("Infotrygd er stengt mellom 21 og 06", kl06IdagEllerNesteDag())
             } else {
                 throw e
             }


### PR DESCRIPTION
… då man ikke kan opprette en task med samme payload, payload er unique

@charliemidtlyng Det jeg er litt usikker på, det er, hva skjer hvis man sender inn en søknad kl 22 som feiler mot infotrygd av en annen grunn enn att infotrygd er "stengt", denne får då rekjøring kl 06.
Men så sender samma person inn en ny søknad rett etter, som ikke feiler.
Då blir vel søknad 2 håndtert som en første søknad? Og nr 1 som en andre? Burde vi gjøre noe for det? 