### PR TITLE
Dependabot samlet:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.3</version>
+        <version>2.4.4</version>
     </parent>
 
     <properties>
@@ -19,16 +19,16 @@
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>11</jvmTarget>
-        <kotlin.version>1.4.31</kotlin.version>
+        <kotlin.version>1.4.32</kotlin.version>
         <springfox.version>3.0.0</springfox.version>
-        <mockk.version>1.10.6</mockk.version>
+        <mockk.version>1.11.0</mockk.version>
         <felles.version>1.20210329154135_57b92f0</felles.version>
         <prosessering.version>1.20210302133042_76527ed</prosessering.version>
-        <confluent.version>6.1.0</confluent.version>
+        <confluent.version>6.1.1</confluent.version>
         <kontrakter.version>2.0_20210413101101_c89b883</kontrakter.version>
         <brukernotifikasjon-skjemas.version>1.2020.11.16-15.17-5f7495d2ba72</brukernotifikasjon-skjemas.version>
-        <token-validation.version>1.3.3</token-validation.version>
-        <spring-cloud.version>3.0.1</spring-cloud.version>
+        <token-validation.version>1.3.5</token-validation.version>
+        <spring-cloud.version>3.0.2</spring-cloud.version>
         <start-class>no.nav.familie.ef.mottak.ApplicationKt</start-class>
 
         <!-- Setter disse til token-support sine versjoner, versjoner(9.x) i spring er ikke kompatibel med oauth2-oidc-sdk -->
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.10.1</version>
+            <version>1.10.2</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>3.3.4</version>
+            <version>4.2.1</version>
         </dependency>
 
         <!-- Nav-internt  -->
@@ -343,7 +343,7 @@
             <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
-                <version>1.10.1</version>
+                <version>1.10.2</version>
 
                 <executions>
                     <execution>


### PR DESCRIPTION
Bump token-validation.version from 1.3.3 to 1.3.5 #483
Bump unleash-client-java from 3.3.4 to 4.2.1
Bump confluent.version from 6.1.0 to 6.1.1
Bump kotlin.version from 1.4.31 to 1.4.32
Bump mockk from 1.10.6 to 1.11.0
Bump spring-cloud.version from 3.0.1 to 3.0.2
Bump avro-maven-plugin from 1.10.1 to 1.10.2
Bump spring-boot-starter-parent from 2.4.3 to 2.4.4
Bump avro from 1.10.1 to 1.10.2