### PR TITLE
Setter manuell oppfølning på tasker som rekjører langt frem i tid.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/HentSaksnummerFraJoarkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/HentSaksnummerFraJoarkTask.kt
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Service
 @TaskStepBeskrivelse(taskStepType = HentSaksnummerFraJoarkTask.TYPE,
                      maxAntallFeil = 20,
                      beskrivelse = "Hent saksnummer fra joark",
-                     triggerTidVedFeilISekunder = 60 * 60 * 12)
+                     triggerTidVedFeilISekunder = 60 * 60 * 12,
+                     settTilManuellOppfølgning = true)
 class HentSaksnummerFraJoarkTask(private val hentJournalpostService: HentJournalpostService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
@@ -18,6 +19,7 @@ class HentSaksnummerFraJoarkTask(private val hentJournalpostService: HentJournal
     }
 
     companion object {
+
         const val TYPE = "hentSaksnummerFraJoark"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SjekkOmJournalpostHarFåttEnSak.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SjekkOmJournalpostHarFåttEnSak.kt
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Service
 @TaskStepBeskrivelse(taskStepType = SjekkOmJournalpostHarFåttEnSak.TYPE,
                      maxAntallFeil = 20,
                      beskrivelse = "Hent saksnummer fra joark",
-                     triggerTidVedFeilISekunder = 60 * 60 * 12)
+                     triggerTidVedFeilISekunder = 60 * 60 * 12,
+                     settTilManuellOppfølgning = true)
 class SjekkOmJournalpostHarFåttEnSak(private val hentJournalpostService: HentJournalpostService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
@@ -18,6 +19,7 @@ class SjekkOmJournalpostHarFåttEnSak(private val hentJournalpostService: HentJo
     }
 
     companion object {
+
         const val TYPE = "hentEksternSaksnummerFraJoark"
     }
 


### PR DESCRIPTION
Vi riskierer att en task feiler kl 16, blir satt til feilet, kl 06 blir den rekjørt og FEILET på nytt. Så kl 7 blir den satt til KLAR_TIL_PLUKK, så vi får aldri fanget den opp fordi den ikke ligger i "FEILET", men klar til plukk. Så blir den rekjørt senere kl 16.30 på nytt, når vi ikker er på jobb. Så den er satt til FEILET mellom 16.30-06.00