### PR TITLE
Dependabot 2 august

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
 
     <properties>
@@ -19,9 +19,9 @@
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>11</jvmTarget>
-        <kotlin.version>1.5.20</kotlin.version>
+        <kotlin.version>1.5.21</kotlin.version>
         <springfox.version>3.0.0</springfox.version>
-        <mockk.version>1.11.0</mockk.version>
+        <mockk.version>1.12.0</mockk.version>
         <felles.version>1.20210712123123_4ab21f1</felles.version>
         <prosessering.version>1.20210617141104_8f0760d</prosessering.version>
         <confluent.version>6.2.0</confluent.version>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>1.5.0-native-mt</version>
+            <version>1.5.1-native-mt</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.28.1</version>
+            <version>2.29.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Sjekket at alt er ok i preprod: 

Bump spring-boot-starter-parent from 2.5.2 to 2.5.3

Bump wiremock-jre8 from 2.28.1 to 2.29.1

Bump kotlin.version from 1.5.10 to 1.5.20  dependencies

Bump kotlinx-coroutines-core from 1.5.0-native-mt to 1.5.1-native-mt

Bump mockk from 1.11.0 to 1.12.0