### PR TITLE
Tar i bruk dokgen i gcp i prod

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ familie:
     integrasjoner:
       url: http://familie-integrasjoner.teamfamilie/api/
     pdfgenerator:
-      url: https://familie-ef-dokgen.nais.adeo.no/
+      url: https://familie-ef-dokgen.intern.nav.no/
 
 prosessering:
   cronRetryTasks: "0 5 6,7 1/1 * ?"


### PR DESCRIPTION
Ref https://github.com/navikt/familie-ef-maler/pull/11

familie-ef-maler i fss i prod i default namespace kan slettes etter denne merge (når det er verifisert att det virker)