### PR TITLE
Setter issuers eksplisitt, sånn att det ikke er mulig å sende inn via…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/PersonController.kt
@@ -3,7 +3,10 @@ package no.nav.familie.ef.mottak.api
 import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.kontrakter.ef.ettersending.SøknadMedDokumentasjonsbehovDto
 import no.nav.familie.kontrakter.felles.PersonIdent
-import no.nav.security.token.support.core.api.Protected
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,11 +16,17 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping(consumes = [APPLICATION_JSON_VALUE], path = ["/api/person"], produces = [APPLICATION_JSON_VALUE])
-@Protected
+@RequiredIssuers(
+        ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER, claimMap = ["acr=Level4"]),
+        ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
+)
 class PersonController(val søknadService: SøknadService) {
 
     @PostMapping("soknader")
     fun søknaderForPerson(@RequestBody personIdent: PersonIdent): ResponseEntity<List<SøknadMedDokumentasjonsbehovDto>> {
+        if (!EksternBrukerUtils.personIdentErLikInnloggetBruker(personIdent.ident)) {
+            throw ApiFeil("Fnr fra token matcher ikke fnr i request", HttpStatus.FORBIDDEN)
+        }
         return ResponseEntity.ok().body(søknadService.hentDokumentasjonsbehovForPerson(personIdent.ident))
     }
 


### PR DESCRIPTION
… azureAd.

Vi trenger strengt tatt ikke sende med ett requestobjekt for disse 2 metodene, då vi like gjerne bare kan hente ut den fra token