### PR TITLE
Featuretoggle kafka listener som skal brukes ved overgang til prod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -17,7 +17,9 @@ class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHån
                    containerFactory = "kafkaJournalføringHendelseListenerContainerFactory",
                    idIsGroup = false)
     fun listen(consumerRecord: ConsumerRecord<Long, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
-        kafkaHåndterer.håndterHendelse(consumerRecord, ack)
+        if (featureToggleService.isEnabled("familie.ef.mottak.kafka.onprem")) {
+            kafkaHåndterer.håndterHendelse(consumerRecord, ack)
+        }
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -19,6 +19,8 @@ class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHån
     fun listen(consumerRecord: ConsumerRecord<Long, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         if (featureToggleService.isEnabled("familie.ef.mottak.kafka.onprem")) {
             kafkaHåndterer.håndterHendelse(consumerRecord, ack)
+        } else {
+            throw Exception("Lytting til topic er skrudd av som følge av migrering til gcp")
         }
     }
 


### PR DESCRIPTION
FeatureToggle er opprettet i unleash og er aktivert: https://unleash.nais.io/#/features/strategies/familie.ef.mottak.kafka.onprem 
Denne skal deaktiveres ved overgang til gcp.