### PR TITLE
Overgang til aiven

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelse.kt
@@ -7,4 +7,4 @@ fun JournalfoeringHendelseRecord.skalProsesseres() = this.erTemaENF() && erHende
 fun JournalfoeringHendelseRecord.erTemaENF() = this.temaNytt?.toString() == "ENF"
 
 fun JournalfoeringHendelseRecord.erHendelsetypeGyldig() =
-        arrayOf("MidlertidigJournalført", "TemaEndret").contains(this.hendelsesType.toString())
+        arrayOf("JournalpostMottatt", "TemaEndret").contains(this.hendelsesType.toString())

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
@@ -27,7 +27,8 @@ class JournalfoeringHendelseDbUtil(val hendelseloggRepository: HendelsesloggRepo
                                           "hendelsesType" to hendelseRecord.hendelsesType.toString()).toProperties()))
     }
 
-    fun erHendelseRegistrertIHendelseslogg(offset: Long): Boolean = hendelseloggRepository.hentMaxOffset() >= offset
+    fun erHendelseRegistrertIHendelseslogg(hendelsesId: String) =
+            hendelseloggRepository.existsByHendelseId(hendelsesId)
 
     fun harIkkeOpprettetOppgaveForJournalpost(hendelseRecord: JournalfoeringHendelseRecord): Boolean {
         return !taskRepository.existsByPayloadAndType(hendelseRecord.journalpostId.toString(),

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
@@ -18,7 +18,7 @@ class JournalhendelseKafkaHåndterer(val journalhendelseService: Journalhendelse
     val feilCounter: Counter = Metrics.counter("alene.med.barn.journalhendelse.feilet")
     val logger: Logger = LoggerFactory.getLogger(JournalhendelseKafkaListener::class.java)
 
-    fun håndterHendelse(consumerRecord: ConsumerRecord<Long, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
+    fun håndterHendelse(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         try {
             val hendelseRecord = consumerRecord.value()
             val callId = hendelseRecord.kanalReferanseId.toStringOrNull() ?: IdUtils.generateId()

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
@@ -20,7 +20,6 @@ class JournalhendelseKafkaHåndterer(val journalhendelseService: Journalhendelse
 
     fun håndterHendelse(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         try {
-            logger.info("Hendelse mottatt. Hendelsetype: ${consumerRecord.value().hendelsesType}")
             val hendelseRecord = consumerRecord.value()
             val callId = hendelseRecord.kanalReferanseId.toStringOrNull() ?: IdUtils.generateId()
             MDC.put(MDCConstants.MDC_CALL_ID, callId)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndterer.kt
@@ -20,6 +20,7 @@ class JournalhendelseKafkaHåndterer(val journalhendelseService: Journalhendelse
 
     fun håndterHendelse(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         try {
+            logger.info("Hendelse mottatt. Hendelsetype: ${consumerRecord.value().hendelsesType}")
             val hendelseRecord = consumerRecord.value()
             val callId = hendelseRecord.kanalReferanseId.toStringOrNull() ?: IdUtils.generateId()
             MDC.put(MDCConstants.MDC_CALL_ID, callId)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ef.mottak.hendelse
 
-import no.nav.familie.ef.mottak.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.mottak.repository.HendelsesloggRepository
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.Logger
@@ -22,6 +20,7 @@ class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHån
                    idIsGroup = false,
                    groupId = "srvfamilie-ef-mot")
     fun listen(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
+        consumerRecord.timestamp()
         kafkaHåndterer.håndterHendelse(consumerRecord, ack)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -5,12 +5,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.ConsumerSeekAware
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Service
 
 
 @Service
-class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHåndterer) {
+class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHåndterer) : ConsumerSeekAware {
 
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
@@ -22,5 +23,17 @@ class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHån
     fun listen(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         consumerRecord.timestamp()
         kafkaHåndterer.håndterHendelse(consumerRecord, ack)
+    }
+
+
+    override fun onPartitionsAssigned(
+        assignments: MutableMap<org.apache.kafka.common.TopicPartition, Long>,
+        callback: ConsumerSeekAware.ConsumerSeekCallback
+    ) {
+        assignments.keys.stream()
+            .filter { it.topic() == "teamdokumenthandtering.aapen-dok-journalfoering" }
+            .forEach {
+                callback.seekRelative("teamdokumenthandtering.aapen-dok-journalfoering", it.partition(), -20, false)
+            }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -21,7 +21,7 @@ class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHån
                    containerFactory = "kafkaJournalføringHendelseListenerContainerFactory",
                    idIsGroup = false,
                    groupId = "srvfamilie-ef-mot")
-    fun listen(consumerRecord: ConsumerRecord<Long, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
+    fun listen(consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>, ack: Acknowledgment) {
         kafkaHåndterer.håndterHendelse(consumerRecord, ack)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaListener.kt
@@ -12,9 +12,7 @@ import org.springframework.stereotype.Service
 
 
 @Service
-class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHåndterer,
-                                   private val featureToggleService: FeatureToggleService,
-                                   private val hendelsesloggRepository: HendelsesloggRepository) {
+class JournalhendelseKafkaListener(val kafkaHåndterer: JournalhendelseKafkaHåndterer) {
 
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseService.kt
@@ -31,7 +31,7 @@ class JournalhendelseService(
     fun prosesserNyHendelse(hendelseRecord: JournalfoeringHendelseRecord, offset: Long) {
 
         secureLogger.info("Mottatt gyldig hendelse: $hendelseRecord")
-        if (!journalfoeringHendelseDbUtil.erHendelseRegistrertIHendelseslogg(offset)) {
+        if (!journalfoeringHendelseDbUtil.erHendelseRegistrertIHendelseslogg(hendelseRecord.hendelsesId.toString())) {
             if (journalfoeringHendelseDbUtil.harIkkeOpprettetOppgaveForJournalpost(hendelseRecord)) {
                 val journalpost = journalpostClient.hentJournalpost(hendelseRecord.journalpostId.toString())
                 journalføringsoppgaveService.lagEksternJournalføringTask(journalpost)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
@@ -9,8 +9,5 @@ import java.util.UUID
 @Repository
 interface HendelsesloggRepository : JpaRepository<Hendelseslogg, UUID> {
 
-    // language=PostgreSQL
-    @Query("""SELECT MAX(kafka_offset) FROM hendelseslogg""", nativeQuery = true)
-    fun hentMaxOffset(): Long
-
+    fun existsByHendelseId(hendelseId: String): Boolean
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Hendelseslogg
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,10 +3,6 @@ spring:
     enabled: true
     placeholders:
       ignoreIfProd:
-  kafka:
-    bootstrap-servers: b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443
-    properties:
-      schema.registry.url: https://kafka-schema-registry.nais-q.adeo.no/
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/familie-ef-mottak
     username: ${DB_USERNAME}
@@ -78,7 +74,6 @@ no.nav.security.jwt:
 
 INFOTRYGD_REPLIKA_API_URL: https://infotrygd-enslig-forsoerger.dev-fss-pub.nais.io
 
-JOURNALFOERINGHENDELSE_V1_TOPIC_URL: aapen-dok-journalfoering-v1-q2
 dittnav.soknadfrontendUrl: https://www-q0.nav.no/familie/alene-med-barn/soknad
 dittnav.ettersendingUrl: https://ensligmorellerfar.dev.nav.no/familie/alene-med-barn/ettersending
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
     bootstrap-servers: ${KAFKA_BROKERS}
     properties:
       schema.registry.url: ${KAFKA_SCHEMA_REGISTRY}
+      basic.auth.credentials.source: USER_INFO
+      basic.auth.user.info: ${KAFKA_SCHEMA_REGISTRY_USER}:${KAFKA_SCHEMA_REGISTRY_PASSWORD}
       security:
         protocol: SSL
       ssl:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,14 +13,20 @@ spring:
     allow-bean-definition-overriding: true
     banner-mode: "off"
   kafka:
-    client-id: familie-ef-mottak
-    bootstrap-servers: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
+    bootstrap-servers: ${KAFKA_BROKERS}
     properties:
-      schema.registry.url: https://kafka-schema-registry.nais.adeo.no
-      security.protocol: SASL_SSL
-      sasl:
-        mechanism: PLAIN
-        jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${SERVICE_USER_USERNAME}" password="${SERVICE_USER_PASSWORD}";
+      schema.registry.url: ${KAFKA_SCHEMA_REGISTRY}
+      security:
+        protocol: SSL
+      ssl:
+        keystore:
+          type: PKCS12
+          location: ${KAFKA_KEYSTORE_PATH}
+          password: ${KAFKA_CREDSTORE_PASSWORD}
+        truststore:
+          type: PKCS12
+          location: ${KAFKA_TRUSTSTORE_PATH}
+          password: ${KAFKA_CREDSTORE_PASSWORD}
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
@@ -97,7 +103,7 @@ database:
 INFOTRYGD_REPLIKA_API_URL: https://infotrygd-enslig-forsoerger.prod-fss-pub.nais.io
 EF_SAK_URL: http://familie-ef-sak
 
-JOURNALFOERINGHENDELSE_V1_TOPIC_URL: aapen-dok-journalfoering-v1-p
+JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering
 KAFKA_ONPREM_BOOTSTRAP_SERVERS: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
 KAFKA_ONPREM_SCHEMA_REGISTRY_URL: https://kafka-schema-registry.nais.adeo.no/
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndtererTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaHåndtererTest.kt
@@ -44,7 +44,7 @@ class JournalhendelseKafkaHåndtererTest {
         val consumerRecord = ConsumerRecord(
                 "topic", 1,
                 OFFSET,
-                42L, ugyldigHendelsetypeRecord
+                "42", ugyldigHendelsetypeRecord
         )
 
         journalhendelseKafkaHåndterer.håndterHendelse(consumerRecord, ack)
@@ -61,7 +61,7 @@ class JournalhendelseKafkaHåndtererTest {
 
         val consumerRecord = ConsumerRecord("topic", 1,
                                             OFFSET,
-                                            42L, ukjentTemaRecord)
+                                            "42", ukjentTemaRecord)
 
         journalhendelseKafkaHåndterer.håndterHendelse(consumerRecord, ack)
 
@@ -76,7 +76,7 @@ class JournalhendelseKafkaHåndtererTest {
         val consumerRecord = ConsumerRecord(
                 "topic", 1,
                 OFFSET,
-                42L, journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
+                "42", journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
         )
         every {
             journalhendelseServiceMock.prosesserNyHendelse(consumerRecord.value(), consumerRecord.offset())
@@ -95,7 +95,7 @@ class JournalhendelseKafkaHåndtererTest {
     fun `send inn gyldig consumer record, forvent acknowledged`() {
         val consumerRecord = ConsumerRecord(
                 "topic", 1, OFFSET,
-                42L, journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
+                "42", journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
         )
 
         every {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
@@ -180,9 +180,9 @@ class JournalhendelseServiceTest {
     }
 
     @Test
-    fun `Skal ignorere hendelse fordi den eksisterer i hendelseslogg da offset er det samme`() {
+    fun `Skal ignorere hendelse fordi hendelseId eksisterer i hendelseslogg-tabellen i db`() {
         val journalføringhendelseRecord = journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
-        every { mockHendelseloggRepository.hentMaxOffset() } returns OFFSET
+        every { mockHendelseloggRepository.existsByHendelseId(any()) } returns true
 
         service.prosesserNyHendelse(journalføringhendelseRecord, OFFSET)
 
@@ -191,21 +191,10 @@ class JournalhendelseServiceTest {
         }
     }
 
-    @Test
-    fun `Skal ignorere hendelse fordi offset i databaser er høyere enn hendelserecord`() {
-        val journalføringhendelseRecord = journalføringHendelseRecord(JOURNALPOST_PAPIRSØKNAD)
-        every { mockHendelseloggRepository.hentMaxOffset() } returns OFFSET + 1
-
-        service.prosesserNyHendelse(journalføringhendelseRecord, OFFSET)
-
-        verify(exactly = 0) {
-            mockHendelseloggRepository.save(any())
-        }
-    }
 
     @Test
     fun `Mottak av gyldig hendelse skal delegeres til service`() {
-        every { mockHendelseloggRepository.hentMaxOffset() } returns OFFSET - 1
+        every { mockHendelseloggRepository.existsByHendelseId(any()) } returns false
 
         every {
             mockTaskRepositoryUtvidet.existsByPayloadAndType(any(), any())

--- a/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
@@ -222,6 +222,6 @@ class JournalhendelseServiceTest {
         assertThat(slot.captured.offset).isEqualTo(OFFSET)
         assertThat(slot.captured.hendelseId).isEqualTo(journalføringHendelseRecord.hendelsesId)
         assertThat(slot.captured.metadata["journalpostId"]).isEqualTo(JOURNALPOST_PAPIRSØKNAD)
-        assertThat(slot.captured.metadata["hendelsesType"]).isEqualTo("MidlertidigJournalført")
+        assertThat(slot.captured.metadata["hendelsesType"]).isEqualTo("JournalpostMottatt")
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepositoryTest.kt
@@ -19,15 +19,9 @@ internal class HendelsesloggRepositoryTest : IntegrasjonSpringRunnerTest() {
     @Test
     internal fun `skal hente max av kafka_offset`() {
         hendelsesloggRepository.save(Hendelseslogg(50, UUID.randomUUID().toString()))
-        hendelsesloggRepository.save(Hendelseslogg(200, UUID.randomUUID().toString()))
+        val hendelseId = UUID.randomUUID().toString()
+        hendelsesloggRepository.save(Hendelseslogg(200, hendelseId))
         hendelsesloggRepository.save(Hendelseslogg(100, UUID.randomUUID().toString()))
-        assertThat(hendelsesloggRepository.hentMaxOffset()).isEqualTo(200)
+        assertThat(hendelsesloggRepository.existsByHendelseId(hendelseId)).isTrue
     }
-
-    @Test
-    internal fun `hvis det ikke finnes offset i databasen fra tidligere har noe gått veldig galt`() {
-        assertThatThrownBy { hendelsesloggRepository.hentMaxOffset() }
-                .isInstanceOf(EmptyResultDataAccessException::class.java)
-    }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/util/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/util/DomainTestUtil.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 fun journalføringHendelseRecord(
         journalpostId: String,
-        hendelseType: String = "MidlertidigJournalført",
+        hendelseType: String = "JournalpostMottatt",
         temaNytt: String = "ENF"
 ) =
         JournalfoeringHendelseRecord(


### PR DESCRIPTION
Testet med noen søknader i dev, og det ser ut til å virke. Det var en endring i data på topic i aiven, og det er endring i joark mapping. Forskjellene er dokumentert her: https://confluence.adeo.no/pages/viewpage.action?pageId=432217859

auto-offset-reset er satt til latest - så den skal hente siste melding på topic første gangen. Med tanke på den korte nedetiden ved deploy, skal det kunne leses fra slutten av topic

Offset er ikke i sync mellom on-prem og gcp, så sikkerhetsmekanismen med å ikke prosessere samme hendelse flere ganger, er gjort om til å ta utgangspunkt i hendelseId fremfor offset. 