### PR TITLE
Fjern toggles som ikke lenger brukes (enablet i alle miljøer)

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -48,23 +48,18 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(private val producer: DittNav
 
     }
 
-    private fun link(søknadId: UUID) = "${dittNavConfig.soknadfrontendUrl}/innsendtsoknad?soknad=$søknadId"
-
     private fun lagLinkMelding(søknad: Søknad, dokumentasjonsbehov: List<Dokumentasjonsbehov>): LinkMelding {
         val søknadType = SøknadType.hentSøknadTypeForDokumenttype(søknad.dokumenttype)
         val søknadstekst = søknadstypeTekst(søknadType)
-        val søknadId = UUID.fromString(søknad.id)
-        val link =
-                if (featureToggleService.isEnabled("familie.ef.mottak.melding-ditt-nav-til-ef-ettersending")) {
-                    ettersendingConfig.ettersendingUrl
-                } else link(søknadId)
+
         return when {
             manglerVedlegg(dokumentasjonsbehov) -> {
-                LinkMelding(link,
+                LinkMelding(ettersendingConfig.ettersendingUrl,
                             "Det ser ut til at det mangler noen vedlegg til søknaden din om $søknadstekst." +
                             " Se hva som mangler og last opp vedlegg.")
             }
-            else -> LinkMelding(link, "Vi har mottatt søknaden din om $søknadstekst. Se vedleggene du lastet opp.")
+            else -> LinkMelding(ettersendingConfig.ettersendingUrl,
+                                "Vi har mottatt søknaden din om $søknadstekst. Se vedleggene du lastet opp.")
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
@@ -39,7 +39,6 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
                                                              mockk(relaxed = true),
                                                              mockk(relaxed = true),
                                                              featureToggleService)
-        mockFeatureToggleMeldingDittNav()
     }
 
     @Test
@@ -132,10 +131,6 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
                        søknadJson = "",
                        dokumenttype = søknadType.dokumentType,
                        fnr = FNR)
-    }
-
-    private fun mockFeatureToggleMeldingDittNav() {
-        every { featureToggleService.isEnabled("familie.ef.mottak.melding-ditt-nav-til-ef-ettersending") } returns false
     }
 
     companion object {


### PR DESCRIPTION
Fjerner bruk av: familie.ef.mottak.melding-ditt-nav-til-ef-ettersending 

![image](https://user-images.githubusercontent.com/53942238/152149138-7fe2f748-46d9-4e74-83bd-03448775af51.png)
