### PR TITLE
Forberedelse for å endre til spring-jdbc. Spring-jdbc har ikke conver…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/encryption/FileCryptoConverter.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/encryption/FileCryptoConverter.kt
@@ -1,15 +1,15 @@
 package no.nav.familie.ef.mottak.encryption
 
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 
 
-class FileCryptoConverter : AbstractCryptoConverter<Fil?>() {
+class FileCryptoConverter : AbstractCryptoConverter<EncryptedFile?>() {
 
-    override fun byteArrayToEntityAttribute(dbData: ByteArray?): Fil? {
-        return dbData?.let { Fil(it) }
+    override fun byteArrayToEntityAttribute(dbData: ByteArray?): EncryptedFile? {
+        return dbData?.let { EncryptedFile(it) }
     }
 
-    override fun entityAttributeToByteArray(attribute: Fil?): ByteArray? {
+    override fun entityAttributeToByteArray(attribute: EncryptedFile?): ByteArray? {
         return attribute?.bytes
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverter.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverter.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.ef.mottak.encryption
 
-class StringValCryptoConverter : AbstractCryptoConverter<String?>() {
+data class EncryptedString(val data: String)
 
-    override fun byteArrayToEntityAttribute(dbData: ByteArray?): String? {
-        return dbData?.let { String(it) }
+class StringValCryptoConverter : AbstractCryptoConverter<EncryptedString?>() {
+
+    override fun byteArrayToEntityAttribute(dbData: ByteArray?): EncryptedString? {
+        return dbData?.let { EncryptedString(String(it)) }
     }
 
-    override fun entityAttributeToByteArray(attribute: String?): ByteArray? {
-        return attribute?.toByteArray()
+    override fun entityAttributeToByteArray(attribute: EncryptedString?): ByteArray? {
+        return attribute?.data?.toByteArray()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfClient.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.mottak.integration
 
 
 import no.nav.familie.ef.mottak.config.PdfgeneratorConfig
-import no.nav.familie.ef.mottak.repository.domain.Fil
 import no.nav.familie.ef.mottak.util.medContentTypeJsonUTF8
 import no.nav.familie.http.client.AbstractRestClient
 import org.springframework.beans.factory.annotation.Qualifier
@@ -17,10 +16,9 @@ class PdfClient(@Qualifier("restTemplateUnsecured") operations: RestOperations,
                 private val pdfgeneratorConfig: PdfgeneratorConfig) :
         AbstractRestClient(operations, "pdf") {
 
-    fun lagPdf(labelValueJson: Map<String, Any>): Fil {
+    fun lagPdf(labelValueJson: Map<String, Any>): ByteArray {
         val sendInnUri =
                 DefaultUriBuilderFactory().uriString(pdfgeneratorConfig.url).path("/api/generer-soknad").build()
-        val byteArray = postForEntity<ByteArray>(sendInnUri, labelValueJson, HttpHeaders().medContentTypeJsonUTF8())
-        return Fil(byteArray)
+        return postForEntity(sendInnUri, labelValueJson, HttpHeaders().medContentTypeJsonUTF8())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/ArkiverDokumentRequestMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/ArkiverDokumentRequestMapper.kt
@@ -21,7 +21,7 @@ object ArkiverDokumentRequestMapper {
               vedlegg: List<Vedlegg>): ArkiverDokumentRequest {
         val dokumenttype = søknad.dokumenttype.let { Dokumenttype.valueOf(it) }
         val søknadsdokumentJson =
-                Dokument(søknad.søknadJson.toByteArray(), Filtype.JSON, null, dokumenttype.dokumentTittel(), dokumenttype)
+                Dokument(søknad.søknadJson.data.toByteArray(), Filtype.JSON, null, dokumenttype.dokumentTittel(), dokumenttype)
         val søknadsdokumentPdf =
                 Dokument(søknad.søknadPdf!!.bytes, Filtype.PDFA, null, dokumenttype.dokumentTittel(), dokumenttype)
         val hoveddokumentvarianter = listOf(søknadsdokumentPdf, søknadsdokumentJson)
@@ -54,7 +54,7 @@ object ArkiverDokumentRequestMapper {
             Dokument(it.bytes, Filtype.PDFA, null, tittel, dokumenttype)
         } ?: error("Mangler forside for ettersendingen")
 
-        val dokumentSomJson = Dokument(ettersending.ettersendingJson.toByteArray(), Filtype.JSON, null, tittel, dokumenttype)
+        val dokumentSomJson = Dokument(ettersending.ettersendingJson.data.toByteArray(), Filtype.JSON, null, tittel, dokumenttype)
 
         return listOf(dokumentSomPdf, dokumentSomJson)
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/EttersendingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/EttersendingMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.mottak.mapper
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
 import no.nav.familie.kontrakter.ef.felles.StønadType
@@ -9,12 +10,12 @@ import no.nav.familie.kontrakter.felles.objectMapper
 object EttersendingMapper {
 
     inline fun <reified T : Any> toDto(ettersending: Ettersending): T {
-        return objectMapper.readValue(ettersending.ettersendingJson)
+        return objectMapper.readValue(ettersending.ettersendingJson.data)
     }
 
     fun fromDto(stønadType: StønadType, ettersending: EttersendelseDto): Ettersending {
         return Ettersending(
-                ettersendingJson = objectMapper.writeValueAsString(ettersending),
+                ettersendingJson = EncryptedString(objectMapper.writeValueAsString(ettersending)),
                 fnr = ettersending.personIdent,
                 stønadType = stønadType.toString(),
         )

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_BARNETILSYN
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKOLEPENGER
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.kontrakter.ef.søknad.SkjemaForArbeidssøker
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
@@ -15,32 +16,32 @@ import no.nav.familie.kontrakter.felles.objectMapper
 object SøknadMapper {
 
     inline fun <reified T : Any> toDto(søknad: Søknad): T {
-        return objectMapper.readValue(søknad.søknadJson)
+        return objectMapper.readValue(søknad.søknadJson.data)
     }
 
     fun fromDto(søknad: SøknadOvergangsstønad, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = objectMapper.writeValueAsString(søknad),
+        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (søknad)),
                       fnr = søknad.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
                       behandleINySaksbehandling = behandleINySaksbehandling)
     }
 
     fun fromDto(søknad: SøknadBarnetilsyn, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = objectMapper.writeValueAsString(søknad),
+        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (søknad)),
                       fnr = søknad.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_BARNETILSYN,
                       behandleINySaksbehandling = behandleINySaksbehandling)
     }
 
     fun fromDto(skjemaForArbeidssøker: SkjemaForArbeidssøker): Søknad {
-        return Søknad(søknadJson = objectMapper.writeValueAsString(skjemaForArbeidssøker),
+        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (skjemaForArbeidssøker)),
                       fnr = skjemaForArbeidssøker.personaliaArbeidssøker.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER,
                       behandleINySaksbehandling = false)
     }
 
     fun fromDto(søknadSkolepenger: SøknadSkolepenger, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = objectMapper.writeValueAsString(søknadSkolepenger),
+        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString(søknadSkolepenger)),
                       fnr = søknadSkolepenger.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_SKOLEPENGER,
                       behandleINySaksbehandling = behandleINySaksbehandling)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
@@ -20,21 +20,21 @@ object SøknadMapper {
     }
 
     fun fromDto(søknad: SøknadOvergangsstønad, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (søknad)),
+        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString(søknad)),
                       fnr = søknad.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
                       behandleINySaksbehandling = behandleINySaksbehandling)
     }
 
     fun fromDto(søknad: SøknadBarnetilsyn, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (søknad)),
+        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString(søknad)),
                       fnr = søknad.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_BARNETILSYN,
                       behandleINySaksbehandling = behandleINySaksbehandling)
     }
 
     fun fromDto(skjemaForArbeidssøker: SkjemaForArbeidssøker): Søknad {
-        return Søknad(søknadJson = EncryptedString( objectMapper.writeValueAsString (skjemaForArbeidssøker)),
+        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString(skjemaForArbeidssøker)),
                       fnr = skjemaForArbeidssøker.personaliaArbeidssøker.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER,
                       behandleINySaksbehandling = false)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EncryptedFile.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EncryptedFile.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ef.mottak.repository.domain
 
 
-data class Fil(val bytes: ByteArray) {
+data class EncryptedFile(val bytes: ByteArray) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
-        return (bytes.contentEquals((other as Fil).bytes))
+        return (bytes.contentEquals((other as EncryptedFile).bytes))
     }
 
     override fun hashCode(): Int {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Ettersending.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Ettersending.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.mottak.repository.domain
 
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
 import no.nav.familie.ef.mottak.encryption.StringValCryptoConverter
 import java.time.LocalDateTime
@@ -16,9 +17,9 @@ data class Ettersending(
         @Id
         val id: UUID = UUID.randomUUID(),
         @Convert(converter = StringValCryptoConverter::class)
-        val ettersendingJson: String,
+        val ettersendingJson: EncryptedString,
         @Convert(converter = FileCryptoConverter::class)
-        val ettersendingPdf: Fil? = null,
+        val ettersendingPdf: EncryptedFile? = null,
         @Column(name = "stonad_type")
         val stønadType: String,
         val journalpostId: String? = null,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EttersendingVedlegg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EttersendingVedlegg.kt
@@ -14,7 +14,7 @@ data class EttersendingVedlegg(@Id
                                val navn: String,
                                val tittel: String,
                                @Convert(converter = FileCryptoConverter::class)
-                               val innhold: Fil) {
+                               val innhold: EncryptedFile) {
 
     @PreUpdate private fun preUpdate() {
         throw UnsupportedOperationException(UPDATE_FEILMELDING)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Søknad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Søknad.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.mottak.repository.domain
 
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
 import no.nav.familie.ef.mottak.encryption.StringValCryptoConverter
 import java.time.LocalDateTime
@@ -16,10 +17,10 @@ data class Søknad(@Id
                   val id: String = UUID.randomUUID().toString(),
                   @Convert(converter = StringValCryptoConverter::class)
                   @Column(name = "soknad_json")
-                  val søknadJson: String,
+                  val søknadJson: EncryptedString,
                   @Convert(converter = FileCryptoConverter::class)
                   @Column(name = "soknad_pdf")
-                  val søknadPdf: Fil? = null,
+                  val søknadPdf: EncryptedFile? = null,
                   val dokumenttype: String,
                   @Column(name = "journalpost_id")
                   val journalpostId: String? = null,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
@@ -16,7 +16,7 @@ data class Vedlegg(@Id
                    val navn: String,
                    val tittel: String,
                    @Convert(converter = FileCryptoConverter::class)
-                   val innhold: Fil) {
+                   val innhold: EncryptedFile) {
 
     @PreUpdate private fun preUpdate() {
         throw UnsupportedOperationException(UPDATE_FEILMELDING)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.EttersendingVedleggRepository
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.EttersendingVedlegg
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.felles.PersonIdent
@@ -41,7 +41,7 @@ class EttersendingService(
     fun hentEttersendingsdataForPerson(personIdent: PersonIdent): List<EttersendelseDto> {
 
         return ettersendingRepository.findAllByFnr(personIdent.ident).map {
-            objectMapper.readValue(it.ettersendingJson)
+            objectMapper.readValue(it.ettersendingJson.data)
         }
     }
 
@@ -54,7 +54,7 @@ class EttersendingService(
                             ettersendingId = ettersendingDbId,
                             navn = vedlegg.navn,
                             tittel = vedlegg.tittel,
-                            innhold = Fil(dokumentClient.hentVedlegg(vedlegg.id))
+                            innhold = EncryptedFile(dokumentClient.hentVedlegg(vedlegg.id))
                     )
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/PdfService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.mottak.mapper.SøknadMapper
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.kontrakter.ef.søknad.SkjemaForArbeidssøker
@@ -30,7 +31,7 @@ class PdfService(private val søknadRepository: SøknadRepository,
         val vedleggTitler = vedleggRepository.findTitlerBySøknadId(id).sorted()
         val feltMap = lagFeltMap(innsending, vedleggTitler)
         val søknadPdf = pdfClient.lagPdf(feltMap)
-        val oppdatertSoknad = innsending.copy(søknadPdf = søknadPdf)
+        val oppdatertSoknad = innsending.copy(søknadPdf = EncryptedFile(søknadPdf))
         søknadRepository.saveAndFlush(oppdatertSoknad)
     }
 
@@ -61,6 +62,6 @@ class PdfService(private val søknadRepository: SøknadRepository,
     fun lagForsideForEttersending(ettersending: Ettersending, vedleggTitler: List<String>) {
         val feltMap = SøknadTreeWalker.mapEttersending(ettersending, vedleggTitler)
         val søknadPdf = pdfClient.lagPdf(feltMap)
-        ettersendingRepository.saveAndFlush(ettersending.copy(ettersendingPdf = søknadPdf))
+        ettersendingRepository.saveAndFlush(ettersending.copy(ettersendingPdf = EncryptedFile(søknadPdf)))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ef.mottak.mapper.SøknadMapper
 import no.nav.familie.ef.mottak.repository.DokumentasjonsbehovRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.repository.domain.Vedlegg
 import no.nav.familie.kontrakter.ef.ettersending.SøknadMedDokumentasjonsbehovDto
@@ -92,7 +92,7 @@ class SøknadService(private val søknadRepository: SøknadRepository,
                         søknadId = søknadDbId,
                         navn = it.navn,
                         tittel = it.tittel,
-                        innhold = Fil(dokumentClient.hentVedlegg(it.id)))
+                        innhold = EncryptedFile(dokumentClient.hentVedlegg(it.id)))
             }
 
     fun get(id: String): Søknad {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/encryption/FilCryptoConverterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/encryption/FilCryptoConverterTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.mottak.encryption
 
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.Base64
@@ -9,7 +9,7 @@ internal class FilCryptoConverterTest {
 
     private val fileCryptoConverter: FileCryptoConverter
 
-    private val fil = Fil(ByteArray(50) { i -> (i * i).toByte() })
+    private val fil = EncryptedFile(ByteArray(50) { i -> (i * i).toByte() })
 
     init {
         KeyProperty("kdjeuyfjkekhndlknvfdekljnolrhsdo")

--- a/src/test/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverterTest.kt
@@ -18,7 +18,7 @@ internal class StringValCryptoConverterTest {
     internal fun `convertToDatabaseColumn konverterer input til String for lagring i base og tilbake til identisk string`() {
         val string = "Bob Marley"
 
-        val convertToDatabaseColumn = stringValCryptoConverter.convertToDatabaseColumn(string)
+        val convertToDatabaseColumn = stringValCryptoConverter.convertToDatabaseColumn(EncryptedString(string))
 
         assertThat(convertToDatabaseColumn).isNotEqualTo("Bob Marley")
     }
@@ -29,7 +29,7 @@ internal class StringValCryptoConverterTest {
 
         val toDatabaseColumn = stringValCryptoConverter.convertToEntityAttribute(Base64.getDecoder().decode(string))
 
-        assertThat(toDatabaseColumn).isEqualTo("Bob Marley")
+        assertThat(toDatabaseColumn?.data).isEqualTo("Bob Marley")
     }
 
     @Test
@@ -38,14 +38,14 @@ internal class StringValCryptoConverterTest {
 
         val byteArrayToEntityAttribute = stringValCryptoConverter.byteArrayToEntityAttribute(byteArray)
 
-        assertThat(byteArrayToEntityAttribute).isEqualTo("bob")
+        assertThat(byteArrayToEntityAttribute?.data).isEqualTo("bob")
     }
 
     @Test
     fun entityAttributeToByteArray() {
         val byteArray = byteArrayOf('b'.code.toByte(), 'o'.code.toByte(), 'b'.code.toByte())
 
-        val entityAttributeToByteArray = stringValCryptoConverter.entityAttributeToByteArray("bob")
+        val entityAttributeToByteArray = stringValCryptoConverter.entityAttributeToByteArray(EncryptedString("bob"))
 
         assertThat(entityAttributeToByteArray).isEqualTo(byteArray)
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mapper/ArkiverDokumentRequestMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mapper/ArkiverDokumentRequestMapperTest.kt
@@ -4,8 +4,9 @@ import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_BARNETILSYN
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKOLEPENGER
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.mapper.ArkiverDokumentRequestMapper.toDto
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.repository.domain.Vedlegg
 import no.nav.familie.ef.mottak.service.Testdata
@@ -54,11 +55,11 @@ internal class ArkiverDokumentRequestMapperTest {
     }
 
     private fun lagSøknad(søknad: Any, dokumenttype: String): Søknad = Søknad(
-            søknadJson = objectMapper.writeValueAsString(søknad),
+            søknadJson = EncryptedString(objectMapper.writeValueAsString(søknad)),
             fnr = "123",
-            søknadPdf = Fil(byteArrayOf(12)),
+            søknadPdf = EncryptedFile(byteArrayOf(12)),
             dokumenttype = dokumenttype
     )
 
-    private fun lagVedlegg() = Vedlegg(UUID.randomUUID(), "id", "navn", "tittel", Fil(byteArrayOf(12)))
+    private fun lagVedlegg() = Vedlegg(UUID.randomUUID(), "id", "navn", "tittel", EncryptedFile(byteArrayOf(12)))
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.mottak.config.IntegrasjonerConfig
 import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.integration.PdfClient
 import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
-import no.nav.familie.ef.mottak.repository.domain.Fil
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
@@ -27,10 +26,10 @@ class MockConfiguration {
     @Profile("mock-pdf")
     fun pdfClient(): PdfClient = object : PdfClient(mockk(), mockk()) {
 
-        override fun lagPdf(labelValueJson: Map<String, Any>): Fil {
+        override fun lagPdf(labelValueJson: Map<String, Any>): ByteArray {
             val pdf = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(labelValueJson)
             log.info("Creating pdf: $pdf")
-            return Fil(labelValueJson.toString().toByteArray())
+            return labelValueJson.toString().toByteArray()
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/SøknadControllerExtension.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/SøknadControllerExtension.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.mottak.mockapi
 
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.security.token.support.core.api.Unprotected
@@ -22,7 +22,7 @@ class SøknadControllerExtension(val søknadService: SøknadService) {
     }
 
     @GetMapping("{id}/pdf")
-    fun getPdf(@PathVariable id: String): Fil? {
+    fun getPdf(@PathVariable id: String): EncryptedFile? {
         return søknadService.get(id).søknadPdf
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.DokumentasjonsbehovRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.domain.Dokumentasjonsbehov
@@ -25,7 +26,7 @@ internal class DokumentasjonsbehovRepositoryTest : IntegrasjonSpringRunnerTest()
     @Test
     internal fun `lagre og hent dokumentasjonsbehov`() {
 
-        val søknad = søknadRepository.save(Søknad(søknadJson = "bob",
+        val søknad = søknadRepository.save(Søknad(søknadJson = EncryptedString("bob"),
                                                   fnr = "ded",
                                                   dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD))
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepositoryTest.kt
@@ -40,7 +40,7 @@ internal class EttersendingRepositoryTest : IntegrasjonSpringRunnerTest() {
 
 
         assertThat(ettersendingRepository.count()).isEqualTo(1)
-        assertThat(objectMapper.readValue(ettersending.ettersendingJson, EttersendelseDto::class.java)).usingRecursiveComparison()
+        assertThat(objectMapper.readValue(ettersending.ettersendingJson.data, EttersendelseDto::class.java)).usingRecursiveComparison()
                 .isEqualTo(ettersendelseDto)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/StatistikkRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/StatistikkRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,8 +22,8 @@ internal class StatistikkRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `søknader - to søknader av overgangsstønad`() {
-        søknadRepository.save(Søknad(søknadJson = "{}", dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
-        søknadRepository.save(Søknad(søknadJson = "{}", dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
+        søknadRepository.save(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
+        søknadRepository.save(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
         val statistikk = statistikkRepository.antallSøknaderPerDokumentType()
         assertThat(statistikk).hasSize(1)
         assertThat(statistikk[0].antall).isEqualTo(2)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepositoryTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.mottak.repository
 import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_BARNETILSYN
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.søknad
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import org.assertj.core.api.Assertions.assertThat
@@ -57,12 +58,12 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
     internal fun `findAllByFnr returnerer flere søknader`() {
         val ident = "12345678"
 
-        val søknadOvergangsstønad = søknadRepository.save(Søknad(søknadJson = "kåre",
+        val søknadOvergangsstønad = søknadRepository.save(Søknad(søknadJson = EncryptedString("kåre"),
                                                                  fnr = ident,
                                                                  dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
                                                                  taskOpprettet = true))
 
-        val søknadBarnetilsyn = søknadRepository.save(Søknad(søknadJson = "kåre",
+        val søknadBarnetilsyn = søknadRepository.save(Søknad(søknadJson = EncryptedString("kåre"),
                                                              fnr = ident,
                                                              dokumenttype = DOKUMENTTYPE_BARNETILSYN,
                                                              taskOpprettet = true))

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepositoryTest.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.søknad
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Vedlegg
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
@@ -24,7 +24,7 @@ internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
     @Test
     internal fun `findBySøknadId returnerer vedlegg`() {
         val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", Fil(byteArrayOf(12))))
+        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
 
         assertThat(vedleggRepository.findBySøknadId(søknadId)).hasSize(1)
         assertThat(vedleggRepository.findBySøknadId("finnes ikke")).isEmpty()
@@ -33,7 +33,7 @@ internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
     @Test
     internal fun `findTitlerBySøknadId returnerer titler`() {
         val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", Fil(byteArrayOf(12))))
+        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
 
         val vedlegg = vedleggRepository.findTitlerBySøknadId(søknadId)
 
@@ -44,16 +44,16 @@ internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
     internal fun `det skal ikke være mulig å oppdatere et vedlegg med ny søknadId`() {
         val vedleggId = UUID.randomUUID()
         val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(vedleggId, søknadId, "navn", "tittel1", Fil(byteArrayOf(12))))
+        vedleggRepository.save(Vedlegg(vedleggId, søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
 
         val søknad2Id = søknadRepository.save(søknad()).id
         assertThat(catchThrowable {
-            vedleggRepository.save(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", Fil(byteArrayOf(12))))
+            vedleggRepository.save(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
         }).isInstanceOf(TransactionSystemException::class.java)
                 .hasRootCauseMessage("Det går ikke å oppdatere vedlegg")
 
         assertThat(catchThrowable {
-            vedleggRepository.saveAll(listOf(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", Fil(byteArrayOf(12)))))
+            vedleggRepository.saveAll(listOf(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", EncryptedFile(byteArrayOf(12)))))
         }).isInstanceOf(TransactionSystemException::class.java)
                 .hasRootCauseMessage("Det går ikke å oppdatere vedlegg")
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/domain/SøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/domain/SøknadTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.mottak.repository.domain
 
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -12,8 +13,8 @@ internal class SøknadTest {
     fun testHashCode() {
         val uuid = UUID.randomUUID().toString()
         val opprettet = LocalDateTime.now()
-        val one = Søknad(uuid, "string", Fil("321".toByteArray()), "", "654", "789", "123", true, opprettet)
-        val other = Søknad(uuid, "string", Fil("321".toByteArray()), "", "654", "789", "123", true, opprettet)
+        val one = opprettSøknad(uuid, opprettet)
+        val other = opprettSøknad(uuid, opprettet)
         assertEquals(one.hashCode(), other.hashCode())
     }
 
@@ -21,8 +22,20 @@ internal class SøknadTest {
     fun testEquals() {
         val uuid = UUID.randomUUID().toString()
         val opprettet = LocalDateTime.now()
-        val one = Søknad(uuid, "string", Fil("321".toByteArray()), "", "654", "789", "123", true, opprettet)
-        val other = Søknad(uuid, "string", Fil("321".toByteArray()), "", "654", "789", "123", true, opprettet)
+        val one = opprettSøknad(uuid, opprettet)
+        val other = opprettSøknad(uuid, opprettet)
         assertTrue(one == other)
     }
+
+    private fun opprettSøknad(uuid: String,
+                              opprettet: LocalDateTime) =
+            Søknad(id = uuid,
+                   søknadJson = EncryptedString("string"),
+                   søknadPdf = EncryptedFile("321".toByteArray()),
+                   dokumenttype = "",
+                   journalpostId = "654",
+                   saksnummer = "789",
+                   fnr = "123",
+                   taskOpprettet = true,
+                   opprettetTid = opprettet)
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.mottak.hendelse.JournalfoeringHendelseDbUtil
 import no.nav.familie.ef.mottak.mockapi.clearAllMocks
@@ -109,7 +110,7 @@ class JournalføringsoppgaveServiceTest {
 
         every { journalpost.journalstatus } returns Journalstatus.MOTTATT
         every { journalpost.kanal } returns "NAV_NO"
-        every { mockEttersendingRepository.findByJournalpostId(any()) } returns Ettersending(ettersendingJson = "",
+        every { mockEttersendingRepository.findByJournalpostId(any()) } returns Ettersending(ettersendingJson = EncryptedString(""),
                                                                                              stønadType = "OVERGANGSSTØNAD",
                                                                                              fnr = "")
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -6,13 +6,14 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.mapper.BehandlesAvApplikasjon
 import no.nav.familie.ef.mottak.mapper.OpprettOppgaveMapper
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.IOTestUtil
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.ef.felles.StønadType
@@ -86,7 +87,7 @@ internal class OppgaveServiceTest {
         every { integrasjonerClient.finnOppgaver(any(), any()) } returns FinnOppgaveResponseDto(0L, emptyList())
         every {
             søknadService.get("123")
-        } returns Søknad(søknadJson = "{}",
+        } returns Søknad(søknadJson = EncryptedString("{}"),
                          dokumenttype = DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER,
                          journalpostId = "999",
                          fnr = Testdata.randomFnr())
@@ -250,8 +251,8 @@ internal class OppgaveServiceTest {
             )
 
     private val ettersending = Ettersending(id = UUID.randomUUID(),
-                                            ettersendingJson = "",
-                                            ettersendingPdf = Fil("abc".toByteArray()),
+                                            ettersendingJson = EncryptedString(""),
+                                            ettersendingPdf = EncryptedFile("abc".toByteArray()),
                                             stønadType = "OVERGANGSSTØNAD",
                                             journalpostId = "123Abc",
                                             fnr = "12345678901",

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/PdfServiceTest.kt
@@ -8,11 +8,12 @@ import io.mockk.verify
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_BARNETILSYN
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKOLEPENGER
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.PdfClient
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
-import no.nav.familie.ef.mottak.repository.domain.Fil
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.Testdata.vedlegg
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -29,7 +30,7 @@ internal class PdfServiceTest {
     private val pdfClient: PdfClient = mockk()
     private val pdfService: PdfService = PdfService(søknadRepository, ettersendingRepository, vedleggRepository, pdfClient)
 
-    private val pdf = Fil("321".toByteArray())
+    private val pdf = EncryptedFile("321".toByteArray())
     private val søknadOvergangsstønadId = "søknadOvergangsstønadId"
     private val søknadOvergangsstønad = Søknad(id = søknadOvergangsstønadId,
                                                søknadJson = createValidSøknadJson(Testdata.søknadOvergangsstønad),
@@ -103,10 +104,10 @@ internal class PdfServiceTest {
         }
     }
 
-    private fun pdfClientVilReturnere(pdf: Fil) {
+    private fun pdfClientVilReturnere(pdf: EncryptedFile) {
         every {
             pdfClient.lagPdf(any())
-        } returns pdf
+        } returns pdf.bytes
     }
 
     private fun søknadsRepositoryVilReturnere(vararg søknad: Søknad) {
@@ -117,8 +118,8 @@ internal class PdfServiceTest {
         }
     }
 
-    private fun createValidSøknadJson(søknad: Any): String {
-        return objectMapper.writeValueAsString(søknad)
+    private fun createValidSøknadJson(søknad: Any): EncryptedString {
+        return EncryptedString(objectMapper.writeValueAsString(søknad))
     }
 
     private fun capturePdfAddedToSøknad(slot: CapturingSlot<Søknad>) {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.mottak.service
 
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.IOTestUtil.readFile
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -94,7 +95,7 @@ class SøknadTreeWalkerTest {
     fun `map ettersending med vedlegg`() {
         val mapEttersending = SøknadTreeWalker.mapEttersending(Ettersending(stønadType = "OVERGANGSSTØNAD",
                                                                             fnr = "23118612345",
-                                                                            ettersendingJson = "",
+                                                                            ettersendingJson = EncryptedString(""),
                                                                             opprettetTid = LocalDateTime.of(2021, 5, 1, 12, 0)),
                                                                listOf("Lærlingkontrakt", "Utgifter til pass av barn"))
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/FerdigstillJournalføringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/FerdigstillJournalføringTaskTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.mottak.task
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.ArkiveringService
@@ -31,7 +32,7 @@ internal class FerdigstillJournalføringTaskTest {
 
         every {
             søknadService.get("123L")
-        } returns Søknad(søknadJson = "",
+        } returns Søknad(søknadJson = EncryptedString(""),
                          dokumenttype = "noe",
                          journalpostId = journalpostId,
                          fnr = FnrGenerator.generer())

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/LagEksternJournalføringsoppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/LagEksternJournalføringsoppgaveTaskTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.mottak.task
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.søknad
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
@@ -54,11 +55,12 @@ internal class LagEksternJournalføringsoppgaveTaskTest {
     @Test
     internal fun `skal ikke opprette ekstern journalføringstask hvis det finnes en ettersending for journalposten`() {
 
-        every { ettersendingRepository.findByJournalpostId(any()) } returns Ettersending(ettersendingJson = "{a:1}",
-                                                                                         stønadType = "OVERGANGSSTØNAD",
-                                                                                         journalpostId = "1",
-                                                                                         fnr = "",
-                                                                                         taskOpprettet = false)
+        every { ettersendingRepository.findByJournalpostId(any()) } returns
+                Ettersending(ettersendingJson = EncryptedString("{a:1}"),
+                             stønadType = "OVERGANGSSTØNAD",
+                             journalpostId = "1",
+                             fnr = "",
+                             taskOpprettet = false)
         every { søknadRepository.findByJournalpostId(any()) } returns null
         every { oppgaveServie.lagJournalføringsoppgaveForJournalpostId(any()) } returns 1
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
@@ -4,6 +4,7 @@ import io.mockk.called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
@@ -128,7 +129,7 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
     private fun mockSøknad(søknadType: SøknadType = SøknadType.OVERGANGSSTØNAD) {
         every { søknadService.get(SØKNAD_ID) } returns
                 Søknad(id = SØKNAD_ID,
-                       søknadJson = "",
+                       søknadJson = EncryptedString(""),
                        dokumenttype = søknadType.dokumentType,
                        fnr = FNR)
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.task
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
 import no.nav.familie.ef.mottak.service.SøknadService
@@ -81,7 +82,7 @@ internal class SendSøknadMottattTilDittNavTaskTest {
         every { søknadService.get(SØKNAD_ID) } returns
                 Søknad(
                         id = SØKNAD_ID,
-                        søknadJson = "",
+                        søknadJson = EncryptedString(""),
                         dokumenttype = søknadType.dokumentType,
                         fnr = FNR
                 )

--- a/src/test/kotlin/no/nav/familie/ef/mottak/util/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/util/DomainTestUtil.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util
 
 import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import java.time.LocalDateTime
@@ -46,7 +47,7 @@ fun søknad(opprettetTid: LocalDateTime = LocalDateTime.now().minusHours(12),
 ) =
         Søknad(
                 id = id,
-                søknadJson = "",
+                søknadJson = EncryptedString(""),
                 fnr = fnr,
                 dokumenttype = dokumenttype,
                 opprettetTid = opprettetTid,


### PR DESCRIPTION
…ters som annotasjoner i domeneobjekt og må regitsreres separat, på objektnivå som skal konveretes.

Endrer navn på fil til EncryptedFile og bruker den kun i domenet, og ikke fra klienter
Wrapper string som skal krypteres med EncryptedString

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8357

Tok å splittet opp https://github.com/navikt/familie-ef-mottak/compare/postgres-testcontainer...spring-jpa-til-jdbc?expand=1 for å få en litt enklere PR med selve overgangen til spring-jdbc