### PR TITLE
Spring jpa til jdbc

### DIFF
--- a/.github/workflows/integrasjonsTest.yml
+++ b/.github/workflows/integrasjonsTest.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          #cache: 'maven'
+          cache: 'maven'
       - name: Bygg (dependabot)
         if: github.actor == 'dependabot[bot]'
         env:

--- a/.github/workflows/integrasjonsTest.yml
+++ b/.github/workflows/integrasjonsTest.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
+          #cache: 'maven'
       - name: Bygg (dependabot)
         if: github.actor == 'dependabot[bot]'
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot-starter-data-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -186,7 +186,7 @@
         </dependency>
         <dependency>
             <groupId>no.nav.familie</groupId>
-            <artifactId>prosessering-jpa</artifactId>
+            <artifactId>prosessering-jdbc</artifactId>
             <version>${prosessering.version}</version>
         </dependency>
 
@@ -356,7 +356,6 @@
                 <configuration>
                     <compilerPlugins>
                         <plugin>spring</plugin>
-                        <plugin>jpa</plugin>
                     </compilerPlugins>
                 </configuration>
             </plugin>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/config/ApplicationConfig.kt
@@ -13,7 +13,6 @@ import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
-import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -21,7 +20,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.client.RestOperations
 import java.time.Duration
@@ -31,8 +29,6 @@ import java.time.temporal.ChronoUnit
 @ComponentScan("no.nav.familie.prosessering",
                "no.nav.familie.sikkerhet",
                "no.nav.familie.ef.mottak")
-@EnableJpaRepositories("no.nav.familie")
-@EntityScan(basePackages = ["no.nav.familie"])
 @ConfigurationPropertiesScan
 @EnableOAuth2Client(cacheEnabled = true)
 @EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])

--- a/src/main/kotlin/no/nav/familie/ef/mottak/config/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/config/DatabaseConfiguration.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ef.mottak.config
+
+import no.nav.familie.ef.mottak.encryption.FileCryptoReadingConverter
+import no.nav.familie.ef.mottak.encryption.FileCryptoWritingConverter
+import no.nav.familie.ef.mottak.encryption.StringValCryptoReadingConverter
+import no.nav.familie.ef.mottak.encryption.StringValCryptoWritingConverter
+import no.nav.familie.prosessering.PropertiesWrapperTilStringConverter
+import no.nav.familie.prosessering.StringTilPropertiesWrapperConverter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
+import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing
+import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
+
+
+@Configuration
+@EnableJdbcAuditing
+@EnableJdbcRepositories("no.nav.familie")
+class DatabaseConfiguration : AbstractJdbcConfiguration() {
+
+    @Bean
+    fun operations(dataSource: DataSource): NamedParameterJdbcOperations {
+        return NamedParameterJdbcTemplate(dataSource)
+    }
+
+    @Bean
+    fun transactionManager(dataSource: DataSource): PlatformTransactionManager {
+        return DataSourceTransactionManager(dataSource)
+    }
+
+    @Bean
+    override fun jdbcCustomConversions(): JdbcCustomConversions {
+        return JdbcCustomConversions(listOf(
+                StringTilPropertiesWrapperConverter(),
+                PropertiesWrapperTilStringConverter(),
+                FileCryptoReadingConverter(),
+                FileCryptoWritingConverter(),
+                StringValCryptoReadingConverter(),
+                StringValCryptoWritingConverter()
+        ))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/encryption/AbstractCryptoConverter.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/encryption/AbstractCryptoConverter.kt
@@ -1,30 +1,42 @@
 package no.nav.familie.ef.mottak.encryption
 
+import org.springframework.core.convert.converter.Converter
 import javax.crypto.Cipher
-import javax.persistence.AttributeConverter
 import kotlin.random.Random
 
+private val cipherInitializer = CipherInitializer()
 
-abstract class AbstractCryptoConverter<T> : AttributeConverter<T, ByteArray> {
-
-    private val cipherInitializer = CipherInitializer()
+abstract class AbstractCryptoReadingConverter<T> : Converter<ByteArray, T> {
 
     abstract fun byteArrayToEntityAttribute(dbData: ByteArray?): T
 
-    abstract fun entityAttributeToByteArray(attribute: T): ByteArray?
-
-    override fun convertToDatabaseColumn(attribute: T): ByteArray? {
-        if (KeyProperty.DATABASE_ENCRYPTION_KEY.isNotEmpty() && attribute != null) {
-            return encrypt(attribute)
-        }
-        return entityAttributeToByteArray(attribute)
-    }
-
-    override fun convertToEntityAttribute(dbData: ByteArray?): T {
+    override fun convert(dbData: ByteArray?): T {
         if (KeyProperty.DATABASE_ENCRYPTION_KEY.isNotEmpty() && dbData != null && dbData.isNotEmpty()) {
             return decrypt(dbData)
         }
         return byteArrayToEntityAttribute(dbData)
+    }
+
+    private fun decrypt(ivAndEncryptedBytes: ByteArray): T {
+        val cipher = cipherInitializer.prepareCipher()
+        val initializationVector = ivAndEncryptedBytes.copyOfRange(0, cipher.blockSize)
+        val encryptedBytes = ivAndEncryptedBytes.copyOfRange(cipher.blockSize, ivAndEncryptedBytes.size)
+        cipherInitializer.initCipher(cipher, Cipher.DECRYPT_MODE, initializationVector)
+        val decryptedBytes = cipher.doFinal(encryptedBytes)
+        return byteArrayToEntityAttribute(decryptedBytes)
+    }
+
+}
+
+abstract class AbstractCryptoWritingConverter<T> : Converter<T, ByteArray> {
+
+    abstract fun entityAttributeToByteArray(attribute: T): ByteArray?
+
+    override fun convert(attribute: T): ByteArray? {
+        if (KeyProperty.DATABASE_ENCRYPTION_KEY.isNotEmpty() && attribute != null) {
+            return encrypt(attribute)
+        }
+        return entityAttributeToByteArray(attribute)
     }
 
     private fun encrypt(attribute: T): ByteArray {
@@ -36,12 +48,4 @@ abstract class AbstractCryptoConverter<T> : AttributeConverter<T, ByteArray> {
         return cipher.iv + encryptedBytes
     }
 
-    private fun decrypt(ivAndEncryptedBytes: ByteArray): T {
-        val cipher = cipherInitializer.prepareCipher()
-        val initializationVector = ivAndEncryptedBytes.copyOfRange(0, cipher.blockSize)
-        val encryptedBytes = ivAndEncryptedBytes.copyOfRange(cipher.blockSize, ivAndEncryptedBytes.size)
-        cipherInitializer.initCipher(cipher, Cipher.DECRYPT_MODE, initializationVector)
-        val decryptedBytes = cipher.doFinal(encryptedBytes)
-        return byteArrayToEntityAttribute(decryptedBytes)
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/encryption/FileCryptoConverter.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/encryption/FileCryptoConverter.kt
@@ -1,15 +1,23 @@
 package no.nav.familie.ef.mottak.encryption
 
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
 
+@WritingConverter
+class FileCryptoWritingConverter : AbstractCryptoWritingConverter<EncryptedFile?>() {
 
-class FileCryptoConverter : AbstractCryptoConverter<EncryptedFile?>() {
+    override fun entityAttributeToByteArray(attribute: EncryptedFile?): ByteArray? {
+        return attribute?.bytes
+    }
+
+}
+
+@ReadingConverter
+class FileCryptoReadingConverter : AbstractCryptoReadingConverter<EncryptedFile?>() {
 
     override fun byteArrayToEntityAttribute(dbData: ByteArray?): EncryptedFile? {
         return dbData?.let { EncryptedFile(it) }
     }
 
-    override fun entityAttributeToByteArray(attribute: EncryptedFile?): ByteArray? {
-        return attribute?.bytes
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverter.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverter.kt
@@ -1,14 +1,24 @@
 package no.nav.familie.ef.mottak.encryption
 
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+
 data class EncryptedString(val data: String)
 
-class StringValCryptoConverter : AbstractCryptoConverter<EncryptedString?>() {
+@WritingConverter
+class StringValCryptoWritingConverter : AbstractCryptoWritingConverter<EncryptedString?>() {
+
+    override fun entityAttributeToByteArray(attribute: EncryptedString?): ByteArray? {
+        return attribute?.data?.toByteArray()
+    }
+
+}
+
+@ReadingConverter
+class StringValCryptoReadingConverter : AbstractCryptoReadingConverter<EncryptedString?>() {
 
     override fun byteArrayToEntityAttribute(dbData: ByteArray?): EncryptedString? {
         return dbData?.let { EncryptedString(String(it)) }
     }
 
-    override fun entityAttributeToByteArray(attribute: EncryptedString?): ByteArray? {
-        return attribute?.data?.toByteArray()
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
@@ -5,12 +5,13 @@ import no.nav.familie.ef.mottak.repository.TaskRepositoryUtvidet
 import no.nav.familie.ef.mottak.repository.domain.Hendelseslogg
 import no.nav.familie.ef.mottak.task.LagEksternJournalføringsoppgaveTask
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class JournalfoeringHendelseDbUtil(val hendelseloggRepository: HendelsesloggRepository,
@@ -21,10 +22,10 @@ class JournalfoeringHendelseDbUtil(val hendelseloggRepository: HendelsesloggRepo
     @Transactional
     fun lagreHendelseslogg(hendelseRecord: JournalfoeringHendelseRecord, offset: Long): Hendelseslogg {
         return hendelseloggRepository
-                .save(Hendelseslogg(offset,
-                                    hendelseRecord.hendelsesId.toString(),
-                                    mapOf("journalpostId" to hendelseRecord.journalpostId.toString(),
-                                          "hendelsesType" to hendelseRecord.hendelsesType.toString()).toProperties()))
+                .insert(Hendelseslogg(offset,
+                                      hendelseRecord.hendelsesId.toString(),
+                                      PropertiesWrapper( mapOf ("journalpostId" to hendelseRecord.journalpostId.toString(),
+                                      "hendelsesType" to hendelseRecord.hendelsesType.toString()).toProperties())))
     }
 
     fun erHendelseRegistrertIHendelseslogg(hendelsesId: String) =
@@ -38,7 +39,7 @@ class JournalfoeringHendelseDbUtil(val hendelseloggRepository: HendelsesloggRepo
     fun lagreEksternJournalføringsTask(journalpost: Journalpost) {
         val journalføringsTask = Task(type = LagEksternJournalføringsoppgaveTask.TYPE,
                                       payload = journalpost.journalpostId,
-                                      metadata = journalpost.metadata())
+                                      properties = journalpost.metadata())
         taskRepository.save(journalføringsTask)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseService.kt
@@ -10,7 +10,7 @@ import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class JournalhendelseService(

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/SøknadMapper.kt
@@ -20,7 +20,7 @@ object SøknadMapper {
     }
 
     fun fromDto(søknad: SøknadOvergangsstønad, behandleINySaksbehandling: Boolean): Søknad {
-        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString(søknad)),
+        return Søknad(søknadJson = EncryptedString(objectMapper.writeValueAsString (søknad)),
                       fnr = søknad.personalia.verdi.fødselsnummer.verdi.verdi,
                       dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
                       behandleINySaksbehandling = behandleINySaksbehandling)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/DbMigreringRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/DbMigreringRepository.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ef.mottak.repository
 
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import no.nav.familie.prosessering.domene.Task
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 
 @Repository
-interface DbMigreringRepository : JpaRepository<Task, Long>
+interface DbMigreringRepository : RepositoryInterface<Task, Long>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepository.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Dokumentasjonsbehov
-import org.springframework.data.jpa.repository.JpaRepository
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import org.springframework.stereotype.Repository
 
 @Repository
-interface DokumentasjonsbehovRepository : JpaRepository<Dokumentasjonsbehov, String>
+interface DokumentasjonsbehovRepository : RepositoryInterface<Dokumentasjonsbehov, String>,
+                                          InsertUpdateRepository<Dokumentasjonsbehov>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepository.kt
@@ -1,13 +1,15 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
-import org.springframework.data.jpa.repository.JpaRepository
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
-interface EttersendingRepository : JpaRepository<Ettersending, UUID> {
+interface EttersendingRepository : RepositoryInterface<Ettersending, UUID>,
+                                   InsertUpdateRepository<Ettersending> {
 
     fun findFirstByTaskOpprettetIsFalse(): Ettersending?
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/EttersendingVedleggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/EttersendingVedleggRepository.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.EttersendingVedlegg
-import org.springframework.data.jpa.repository.JpaRepository
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface EttersendingVedleggRepository : JpaRepository<EttersendingVedlegg, UUID> {
+interface EttersendingVedleggRepository : RepositoryInterface<EttersendingVedlegg, UUID>,
+                                          InsertUpdateRepository<EttersendingVedlegg> {
 
     fun findByEttersendingId(ettersendingId: UUID): List<EttersendingVedlegg>
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepository.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Hendelseslogg
-import org.springframework.data.jpa.repository.JpaRepository
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface HendelsesloggRepository : JpaRepository<Hendelseslogg, UUID> {
+interface HendelsesloggRepository : RepositoryInterface<Hendelseslogg, UUID>,
+                                    InsertUpdateRepository<Hendelseslogg> {
 
     fun existsByHendelseId(hendelseId: String): Boolean
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
@@ -1,12 +1,14 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Søknad
-import org.springframework.data.jpa.repository.JpaRepository
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
-interface SøknadRepository : JpaRepository<Søknad, String> {
+interface SøknadRepository : RepositoryInterface<Søknad, String>,
+                             InsertUpdateRepository<Søknad> {
 
     fun findFirstByTaskOpprettetIsFalse(): Søknad?
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/TaskMetricRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/TaskMetricRepository.kt
@@ -2,13 +2,13 @@ package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.FeiletTaskMetric
 import no.nav.familie.prosessering.domene.Task
-import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface TaskMetricRepository : org.springframework.data.repository.Repository<Task, String> {
 
-    @Query("""SELECT new no.nav.familie.ef.mottak.repository.domain.FeiletTaskMetric(t.type, count(t.id)) FROM Task t
+    @Query("""SELECT t.type, count(t.id) as count FROM Task t
                     WHERE t.status = 'FEILET'
                     GROUP by t.type""")
     fun finnFeiledeTasks(): List<FeiletTaskMetric>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepository.kt
@@ -1,16 +1,18 @@
 package no.nav.familie.ef.mottak.repository
 
 import no.nav.familie.ef.mottak.repository.domain.Vedlegg
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import no.nav.familie.ef.mottak.repository.util.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface VedleggRepository : JpaRepository<Vedlegg, String> {
+interface VedleggRepository : RepositoryInterface<Vedlegg, String>,
+                              InsertUpdateRepository<Vedlegg> {
 
     fun findBySøknadId(søknadId: String): List<Vedlegg>
 
-    @Query(nativeQuery = true, value = "SELECT tittel FROM vedlegg WHERE soknad_id=:søknadId")
+    @Query("SELECT tittel FROM vedlegg WHERE soknad_id=:søknadId")
     fun findTitlerBySøknadId(søknadId: String): List<String>
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Dokumentasjonsbehov.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Dokumentasjonsbehov.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ef.mottak.repository.domain
 
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.Id
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 
-@Entity
 data class Dokumentasjonsbehov(@Id
-                               @Column(name = "soknad_id")
+                               @Column("soknad_id")
                                val søknadId: String,
                                val data: String)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Ettersending.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Ettersending.kt
@@ -1,26 +1,17 @@
 package no.nav.familie.ef.mottak.repository.domain
 
 import no.nav.familie.ef.mottak.encryption.EncryptedString
-import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
-import no.nav.familie.ef.mottak.encryption.StringValCryptoConverter
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.persistence.Column
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.Table
 
-@Entity
-@Table(name = "ettersending")
 data class Ettersending(
         @Id
         val id: UUID = UUID.randomUUID(),
-        @Convert(converter = StringValCryptoConverter::class)
         val ettersendingJson: EncryptedString,
-        @Convert(converter = FileCryptoConverter::class)
         val ettersendingPdf: EncryptedFile? = null,
-        @Column(name = "stonad_type")
+        @Column("stonad_type")
         val stønadType: String,
         val journalpostId: String? = null,
         val fnr: String,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EttersendingVedlegg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/EttersendingVedlegg.kt
@@ -1,24 +1,14 @@
 package no.nav.familie.ef.mottak.repository.domain
 
-import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
+import org.springframework.data.annotation.Id
 import java.util.UUID
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.PreUpdate
 
-@Entity
 data class EttersendingVedlegg(@Id
                                val id: UUID,
                                val ettersendingId: UUID,
                                val navn: String,
                                val tittel: String,
-                               @Convert(converter = FileCryptoConverter::class)
                                val innhold: EncryptedFile) {
-
-    @PreUpdate private fun preUpdate() {
-        throw UnsupportedOperationException(UPDATE_FEILMELDING)
-    }
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Hendelseslogg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Hendelseslogg.kt
@@ -1,34 +1,34 @@
 package no.nav.familie.ef.mottak.repository.domain
 
-import no.nav.familie.prosessering.domene.PropertiesToStringConverter
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
+import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDateTime
 import java.util.Properties
 import java.util.UUID
-import javax.persistence.Column
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.Table
 
-@Entity
-@Table(name = "HENDELSESLOGG")
 data class Hendelseslogg(
-        @Column(name = "kafka_offset")
+        @Column("kafka_offset")
         val offset: Long,
 
-        @Column(name = "hendelse_id")
+        @Column("hendelse_id")
         val hendelseId: String,
 
-        @Convert(converter = PropertiesToStringConverter::class)
-        @Column(name = "metadata")
-        val metadata: Properties = Properties(),
+        @Column("metadata")
+        val metadataWrapper: PropertiesWrapper = PropertiesWrapper(Properties()),
 
         @Id
         val id: UUID = UUID.randomUUID(),
 
-        @Column(name = "opprettet_tid", nullable = false, updatable = false)
+        @Column("opprettet_tid")
         val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
 
-        @Column(name = "ident", nullable = true)
+        @Column("ident")
         val ident: String? = null
-)
+) {
+
+    @Transient
+    val metadata: Properties = metadataWrapper.properties
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Søknad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Søknad.kt
@@ -1,34 +1,23 @@
 package no.nav.familie.ef.mottak.repository.domain
 
 import no.nav.familie.ef.mottak.encryption.EncryptedString
-import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
-import no.nav.familie.ef.mottak.encryption.StringValCryptoConverter
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.persistence.Column
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.Table
 
-@Entity
-@Table(name = "soknad")
+@Table("soknad")
 data class Søknad(@Id
                   val id: String = UUID.randomUUID().toString(),
-                  @Convert(converter = StringValCryptoConverter::class)
-                  @Column(name = "soknad_json")
+                  @Column("soknad_json")
                   val søknadJson: EncryptedString,
-                  @Convert(converter = FileCryptoConverter::class)
-                  @Column(name = "soknad_pdf")
+                  @Column("soknad_pdf")
                   val søknadPdf: EncryptedFile? = null,
                   val dokumenttype: String,
-                  @Column(name = "journalpost_id")
                   val journalpostId: String? = null,
                   val saksnummer: String? = null,
                   val fnr: String,
-                  @Column(name = "task_opprettet")
                   val taskOpprettet: Boolean = false,
-                  @Column(name = "opprettet_tid")
                   val opprettetTid: LocalDateTime = LocalDateTime.now(),
-                  @Column(name = "behandle_i_ny_saksbehandling")
                   val behandleINySaksbehandling: Boolean = false)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/domain/Vedlegg.kt
@@ -1,29 +1,13 @@
 package no.nav.familie.ef.mottak.repository.domain
 
-import no.nav.familie.ef.mottak.encryption.FileCryptoConverter
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import java.util.UUID
-import javax.persistence.Column
-import javax.persistence.Convert
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.PreUpdate
 
-@Entity
 data class Vedlegg(@Id
                    val id: UUID,
-                   @Column(name = "soknad_id")
+                   @Column("soknad_id")
                    val søknadId: String,
                    val navn: String,
                    val tittel: String,
-                   @Convert(converter = FileCryptoConverter::class)
-                   val innhold: EncryptedFile) {
-
-    @PreUpdate private fun preUpdate() {
-        throw UnsupportedOperationException(UPDATE_FEILMELDING)
-    }
-
-    companion object {
-
-        const val UPDATE_FEILMELDING: String = "Det går ikke å oppdatere vedlegg"
-    }
-}
+                   val innhold: EncryptedFile)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/InsertUpdateRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/InsertUpdateRepository.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.ef.mottak.repository.util
+
+interface InsertUpdateRepository<T> {
+
+    fun insert(t: T): T
+    fun insertAll(list: List<T>): List<T>
+
+    fun update(t: T): T
+    fun updateAll(list: List<T>): List<T>
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/InsertUpdateRepositoryImpl.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/InsertUpdateRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ef.mottak.repository.util
+
+import no.nav.familie.ef.mottak.repository.util.InsertUpdateRepository
+import org.springframework.data.jdbc.core.JdbcAggregateOperations
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class InsertUpdateRepositoryImpl<T>(val entityOperations: JdbcAggregateOperations) : InsertUpdateRepository<T> {
+
+    @Transactional
+    override fun insert(t: T): T {
+        return entityOperations.insert(t)
+    }
+
+    @Transactional
+    override fun insertAll(list: List<T>): List<T> {
+        return list.map(this::insert)
+    }
+
+    @Transactional
+    override fun update(t: T): T {
+        return entityOperations.update(t)
+    }
+
+    @Transactional
+    override fun updateAll(list: List<T>): List<T> {
+        return list.map(this::update)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/RepositoryInterface.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/RepositoryInterface.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.ef.mottak.repository.util
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.NoRepositoryBean
+
+/**
+ * På grunn av att vi setter id's på våre entitetet så prøver spring å oppdatere våre entiteter i stedet for å ta insert
+ */
+@NoRepositoryBean
+interface RepositoryInterface<T, ID> : CrudRepository<T, ID> {
+
+    @Deprecated("Støttes ikke, bruk insert/update")
+    override fun <S : T> save(entity: S): S {
+        error("Not implemented - Use InsertUpdateRepository - insert/update")
+    }
+
+    @Deprecated("Støttes ikke, bruk insertAll/updateAll")
+    override fun <S : T> saveAll(entities: Iterable<S>): Iterable<S> {
+        error("Not implemented - Use InsertUpdateRepository - insertAll/updateAll")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/RepositoryUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/util/RepositoryUtil.kt
@@ -1,0 +1,17 @@
+package no.nav.familie.ef.mottak.repository.util
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.findByIdOrNull
+
+inline fun <reified T, ID> CrudRepository<T, ID>.findByIdOrThrow(id: ID): T {
+    return findByIdOrNull(id) ?: throw IllegalStateException("Finner ikke ${T::class.simpleName} med id=$id")
+}
+
+inline fun <reified T, ID> CrudRepository<T, ID>.findAllByIdOrThrow(ids: Set<ID>, getId: (T) -> ID): List<T> {
+    val result = findAllById(ids).toList()
+    val resultPerId = result.map(getId)
+    require(resultPerId.containsAll(ids)) {
+        "Finner ikke ${T::class.simpleName} for ${ids.filterNot(resultPerId::contains)}"
+    }
+    return result
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
@@ -44,7 +44,7 @@ class ArkiveringService(private val integrasjonerClient: IntegrasjonerClient,
         val vedlegg = ettersendingVedleggRepository.findByEttersendingId(ettersending.id)
         val journalpostId: String = sendEttersending(ettersending, vedlegg)
         val ettersendingMedJournalpostId = ettersending.copy(journalpostId = journalpostId)
-        ettersendingService.lagreEttersending(ettersendingMedJournalpostId)
+        ettersendingService.oppdaterEttersending(ettersendingMedJournalpostId)
         return journalpostId
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
@@ -35,7 +35,7 @@ class ArkiveringService(private val integrasjonerClient: IntegrasjonerClient,
         val journalpostId: String = send(søknad, vedlegg)
         val søknadMedJournalpostId = søknad.copy(journalpostId = journalpostId)
         logger.info("Oppdaterer søknad med journalpostId")
-        søknadService.lagreSøknad(søknadMedJournalpostId)
+        søknadService.oppdaterSøknad(søknadMedJournalpostId)
         return journalpostId
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
@@ -72,7 +72,7 @@ class EttersendingService(
         return ettersendingRepository.findByIdOrNull(UUID.fromString(id)) ?: error("Ugyldig primærnøkkel")
     }
 
-    fun lagreEttersending(ettersending: Ettersending) {
-        ettersendingRepository.insert(ettersending)
+    fun oppdaterEttersending(ettersending: Ettersending) {
+        ettersendingRepository.update(ettersending)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
@@ -6,9 +6,9 @@ import no.nav.familie.ef.mottak.integration.FamilieDokumentClient
 import no.nav.familie.ef.mottak.mapper.EttersendingMapper
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.EttersendingVedleggRepository
+import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.EttersendingVedlegg
-import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.kontrakter.ef.ettersending.EttersendelseDto
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.felles.PersonIdent
@@ -63,8 +63,8 @@ class EttersendingService(
             ettersendingDb: Ettersending,
             vedlegg: List<EttersendingVedlegg>,
     ) {
-        val lagretSkjema = ettersendingRepository.save(ettersendingDb)
-        ettersendingVedleggRepository.saveAll(vedlegg)
+        val lagretSkjema = ettersendingRepository.insert(ettersendingDb)
+        ettersendingVedleggRepository.insertAll(vedlegg)
         logger.info("Mottatt ettersending med id ${lagretSkjema.id}")
     }
 
@@ -73,6 +73,6 @@ class EttersendingService(
     }
 
     fun lagreEttersending(ettersending: Ettersending) {
-        ettersendingRepository.save(ettersending)
+        ettersendingRepository.insert(ettersending)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/PdfService.kt
@@ -26,13 +26,12 @@ class PdfService(private val søknadRepository: SøknadRepository,
                  private val pdfClient: PdfClient) {
 
     fun lagPdf(id: String) {
-
         val innsending = søknadRepository.findByIdOrNull(id) ?: error("Kunne ikke finne søknad ($id) i database")
         val vedleggTitler = vedleggRepository.findTitlerBySøknadId(id).sorted()
         val feltMap = lagFeltMap(innsending, vedleggTitler)
         val søknadPdf = pdfClient.lagPdf(feltMap)
         val oppdatertSoknad = innsending.copy(søknadPdf = EncryptedFile(søknadPdf))
-        søknadRepository.saveAndFlush(oppdatertSoknad)
+        søknadRepository.update(oppdatertSoknad)
     }
 
     private fun lagFeltMap(innsending: Søknad, vedleggTitler: List<String>): Map<String, Any> {
@@ -62,6 +61,6 @@ class PdfService(private val søknadRepository: SøknadRepository,
     fun lagForsideForEttersending(ettersending: Ettersending, vedleggTitler: List<String>) {
         val feltMap = SøknadTreeWalker.mapEttersending(ettersending, vedleggTitler)
         val søknadPdf = pdfClient.lagPdf(feltMap)
-        ettersendingRepository.saveAndFlush(ettersending.copy(ettersendingPdf = EncryptedFile(søknadPdf)))
+        ettersendingRepository.update(ettersending.copy(ettersendingPdf = EncryptedFile(søknadPdf)))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -138,7 +138,8 @@ class SøknadService(private val søknadRepository: SøknadRepository,
                                       søknadType = SøknadType.hentSøknadTypeForDokumenttype(søknad.dokumenttype))
     }
 
-    fun lagreSøknad(søknad: Søknad) {
-        søknadRepository.insert(søknad)
+    fun oppdaterSøknad(søknad: Søknad) {
+        søknadRepository.update(søknad)
     }
+
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -75,12 +75,12 @@ class SøknadService(private val søknadRepository: SøknadRepository,
     private fun motta(søknadDb: Søknad,
                       vedlegg: List<Vedlegg>,
                       dokumentasjonsbehov: List<Dokumentasjonsbehov>): Kvittering {
-        val lagretSkjema = søknadRepository.save(søknadDb)
-        vedleggRepository.saveAll(vedlegg)
+        val lagretSkjema = søknadRepository.insert(søknadDb)
+        vedleggRepository.insertAll(vedlegg)
 
         val databaseDokumentasjonsbehov = DatabaseDokumentasjonsbehov(søknadId = lagretSkjema.id,
                                                                       data = objectMapper.writeValueAsString(dokumentasjonsbehov))
-        dokumentasjonsbehovRepository.save(databaseDokumentasjonsbehov)
+        dokumentasjonsbehovRepository.insert(databaseDokumentasjonsbehov)
         logger.info("Mottatt søknad med id ${lagretSkjema.id}")
         return Kvittering(lagretSkjema.id, "Søknad lagret med id ${lagretSkjema.id} er registrert mottatt.")
     }
@@ -102,7 +102,7 @@ class SøknadService(private val søknadRepository: SøknadRepository,
     @Transactional
     fun motta(skjemaForArbeidssøker: SkjemaForArbeidssøker): Kvittering {
         val søknadDb = SøknadMapper.fromDto(skjemaForArbeidssøker)
-        val lagretSkjema = søknadRepository.save(søknadDb)
+        val lagretSkjema = søknadRepository.insert(søknadDb)
         logger.info("Mottatt skjema med id ${lagretSkjema.id}")
 
         return Kvittering(søknadDb.id, "Skjema er mottatt og lagret med id ${lagretSkjema.id}.")
@@ -139,6 +139,6 @@ class SøknadService(private val søknadRepository: SøknadRepository,
     }
 
     fun lagreSøknad(søknad: Søknad) {
-        søknadRepository.save(søknad)
+        søknadRepository.insert(søknad)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
@@ -32,7 +32,7 @@ class TaskProsesseringService(private val taskRepository: TaskRepository,
         taskRepository.save(Task(SendSøknadMottattTilDittNavTask.TYPE,
                                  søknad.id,
                                  properties))
-        søknadRepository.save(søknad.copy(taskOpprettet = true))
+        søknadRepository.insert(søknad.copy(taskOpprettet = true))
     }
 
     @Transactional
@@ -44,7 +44,7 @@ class TaskProsesseringService(private val taskRepository: TaskRepository,
                 }
 
         taskRepository.save(Task(LagEttersendingPdfTask.TYPE, ettersending.id.toString(), properties))
-        ettersendingRepository.save(ettersending.copy(taskOpprettet = true))
+        ettersendingRepository.insert(ettersending.copy(taskOpprettet = true))
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
@@ -32,7 +32,7 @@ class TaskProsesseringService(private val taskRepository: TaskRepository,
         taskRepository.save(Task(SendSøknadMottattTilDittNavTask.TYPE,
                                  søknad.id,
                                  properties))
-        søknadRepository.insert(søknad.copy(taskOpprettet = true))
+        søknadRepository.update(søknad.copy(taskOpprettet = true))
     }
 
     @Transactional
@@ -44,7 +44,7 @@ class TaskProsesseringService(private val taskRepository: TaskRepository,
                 }
 
         taskRepository.save(Task(LagEttersendingPdfTask.TYPE, ettersending.id.toString(), properties))
-        ettersendingRepository.insert(ettersending.copy(taskOpprettet = true))
+        ettersendingRepository.update(ettersending.copy(taskOpprettet = true))
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverEttersendingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverEttersendingTask.kt
@@ -27,7 +27,6 @@ class ArkiverEttersendingTask(private val arkiveringService: ArkiveringService,
             this["journalpostId"] = journalpostId
         }
         antallEttersendinger.increment()
-        taskRepository.save(task)
     }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverSøknadTask.kt
@@ -29,7 +29,6 @@ class ArkiverSøknadTask(private val arkiveringService: ArkiveringService,
             this["journalpostId"] = journalpostId
         }
         logger.info("Journalfør søknad for task=${task.id}")
-        taskRepository.save(task)
     }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/LagBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/LagBehandleSakOppgaveTask.kt
@@ -41,7 +41,6 @@ class LagBehandleSakOppgaveTask(private val oppgaveService: OppgaveService,
             task.metadata.apply {
                 this[behandleSakOppgaveIdKey] = lagBehandleSakOppgave.toString()
             }
-            taskRepository.save(task)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/LagJournalføringsoppgaveForEttersendingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/LagJournalføringsoppgaveForEttersendingTask.kt
@@ -21,7 +21,6 @@ class LagJournalføringsoppgaveForEttersendingTask(private val oppgaveService: O
             }
 
         }
-        taskRepository.save(task)
     }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/LagJournalføringsoppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/LagJournalføringsoppgaveTask.kt
@@ -20,7 +20,6 @@ class LagJournalføringsoppgaveTask(private val taskRepository: TaskRepository,
                 this[journalføringOppgaveIdKey] = oppgaveId.toString()
             }
         }
-        taskRepository.save(task)
     }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
@@ -36,7 +36,7 @@ class OpprettSakTask(private val taskRepository: TaskRepository,
             val sakId = sakService.opprettSak(task.payload, oppgaveId)?.trim()
             val soknad = søknadRepository.findByIdOrNull(task.payload) ?: error("Søknad har forsvunnet!")
             val soknadMedSaksnummer = soknad.copy(saksnummer = sakId)
-            søknadRepository.save(soknadMedSaksnummer)
+            søknadRepository.insert(soknadMedSaksnummer)
             opprettNesteTask(task, soknadMedSaksnummer)
         } catch (e: Exception) {
             if (erKlokkenMellom21Og06()) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTask.kt
@@ -36,7 +36,7 @@ class OpprettSakTask(private val taskRepository: TaskRepository,
             val sakId = sakService.opprettSak(task.payload, oppgaveId)?.trim()
             val soknad = søknadRepository.findByIdOrNull(task.payload) ?: error("Søknad har forsvunnet!")
             val soknadMedSaksnummer = soknad.copy(saksnummer = sakId)
-            søknadRepository.insert(soknadMedSaksnummer)
+            søknadRepository.update(soknadMedSaksnummer)
             opprettNesteTask(task, soknadMedSaksnummer)
         } catch (e: Exception) {
             if (erKlokkenMellom21Og06()) {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/util/VedleggUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/util/VedleggUtils.kt
@@ -2,14 +2,14 @@ package no.nav.familie.ef.mottak.util
 
 import no.nav.familie.ef.mottak.api.ApiFeil
 import no.nav.familie.ef.mottak.api.dto.Kvittering
-import no.nav.familie.ef.mottak.repository.domain.Vedlegg
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.HttpStatus
 
 fun okEllerKastException(producer: () -> Kvittering): Kvittering {
     try {
         return producer.invoke()
     } catch (e: Exception) {
-        if (e.getRootCause()?.message == Vedlegg.UPDATE_FEILMELDING) {
+        if (e.cause is DuplicateKeyException) {
             throw ApiFeil("Det går ikke å sende inn samme vedlegg to ganger", HttpStatus.BAD_REQUEST)
         } else {
             throw e

--- a/src/main/resources/db/migration/V22__task_id_serial.sql
+++ b/src/main/resources/db/migration/V22__task_id_serial.sql
@@ -1,0 +1,5 @@
+ALTER TABLE task
+    ALTER COLUMN id SET DEFAULT NEXTVAL('task_seq');
+
+ALTER TABLE task_logg
+    ALTER COLUMN id SET DEFAULT NEXTVAL('task_logg_seq');

--- a/src/test/kotlin/no/nav/familie/ef/mottak/encryption/FilCryptoConverterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/encryption/FilCryptoConverterTest.kt
@@ -7,21 +7,23 @@ import java.util.Base64
 
 internal class FilCryptoConverterTest {
 
-    private val fileCryptoConverter: FileCryptoConverter
+    private val fileCryptoReadingConverter: FileCryptoReadingConverter
+    private val fileCryptoWritingConverter: FileCryptoWritingConverter
 
-    private val fil = EncryptedFile(ByteArray(50) { i -> (i * i).toByte() })
+    private val encryptedFile = EncryptedFile(ByteArray(50) { i -> (i * i).toByte() })
 
     init {
         KeyProperty("kdjeuyfjkekhndlknvfdekljnolrhsdo")
-        fileCryptoConverter = FileCryptoConverter()
+        fileCryptoReadingConverter = FileCryptoReadingConverter()
+        fileCryptoWritingConverter = FileCryptoWritingConverter()
     }
 
 
     @Test
     internal fun `convertToDatabaseColumn konverterer input til String for lagring i base og tilbake til identisk string`() {
-        val convertToDatabaseColumn = fileCryptoConverter.convertToDatabaseColumn(fil)
+        val convertToDatabaseColumn = fileCryptoWritingConverter.convert(encryptedFile)
 
-        Assertions.assertThat(convertToDatabaseColumn).isNotEqualTo(fil)
+        Assertions.assertThat(convertToDatabaseColumn).isNotEqualTo(encryptedFile)
     }
 
     @Test
@@ -30,9 +32,9 @@ internal class FilCryptoConverterTest {
         val encrypted = "wIFKKv38vySQRm7Y9Pusv2lzEy9I9/IyM4/UkA2e7RiziKK2oVz1K/N" +
                         "uU8DyXHh2vZsWvkCz7Bx0VCMwbO0VEUt4shyTDxYhuB5OdV0Utrk="
 
-        val convertToEntityAttribute = fileCryptoConverter.convertToEntityAttribute(Base64.getDecoder().decode(encrypted))
+        val convertToEntityAttribute = fileCryptoReadingConverter.convert(Base64.getDecoder().decode(encrypted))
 
-        Assertions.assertThat(convertToEntityAttribute).isEqualTo(fil)
+        Assertions.assertThat(convertToEntityAttribute).isEqualTo(encryptedFile)
 
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/encryption/StringValCryptoConverterTest.kt
@@ -6,11 +6,13 @@ import java.util.Base64
 
 internal class StringValCryptoConverterTest {
 
-    private val stringValCryptoConverter: StringValCryptoConverter
+    private val stringValCryptoReadingConverter: StringValCryptoReadingConverter
+    private val stringValCryptoWritingConverter: StringValCryptoWritingConverter
 
     init {
         KeyProperty("kdjeuyfjkekhndlknvfdekljnolrhsdo")
-        stringValCryptoConverter = StringValCryptoConverter()
+        stringValCryptoReadingConverter = StringValCryptoReadingConverter()
+        stringValCryptoWritingConverter = StringValCryptoWritingConverter()
     }
 
 
@@ -18,7 +20,7 @@ internal class StringValCryptoConverterTest {
     internal fun `convertToDatabaseColumn konverterer input til String for lagring i base og tilbake til identisk string`() {
         val string = "Bob Marley"
 
-        val convertToDatabaseColumn = stringValCryptoConverter.convertToDatabaseColumn(EncryptedString(string))
+        val convertToDatabaseColumn = stringValCryptoWritingConverter.convert(EncryptedString(string))
 
         assertThat(convertToDatabaseColumn).isNotEqualTo("Bob Marley")
     }
@@ -27,7 +29,7 @@ internal class StringValCryptoConverterTest {
     internal fun `convertToDatabaseColumn konverterer input til String for lagring i base`() {
         val string = "UQO9DFBIipAyzXzGIG6XmGT3fOBDdIFA6AvpH3Adpow="
 
-        val toDatabaseColumn = stringValCryptoConverter.convertToEntityAttribute(Base64.getDecoder().decode(string))
+        val toDatabaseColumn = stringValCryptoReadingConverter.convert(Base64.getDecoder().decode(string))
 
         assertThat(toDatabaseColumn?.data).isEqualTo("Bob Marley")
     }
@@ -36,7 +38,7 @@ internal class StringValCryptoConverterTest {
     fun byteArrayToEntityAttribute() {
         val byteArray = byteArrayOf('b'.code.toByte(), 'o'.code.toByte(), 'b'.code.toByte())
 
-        val byteArrayToEntityAttribute = stringValCryptoConverter.byteArrayToEntityAttribute(byteArray)
+        val byteArrayToEntityAttribute = stringValCryptoReadingConverter.byteArrayToEntityAttribute(byteArray)
 
         assertThat(byteArrayToEntityAttribute?.data).isEqualTo("bob")
     }
@@ -45,7 +47,7 @@ internal class StringValCryptoConverterTest {
     fun entityAttributeToByteArray() {
         val byteArray = byteArrayOf('b'.code.toByte(), 'o'.code.toByte(), 'b'.code.toByte())
 
-        val entityAttributeToByteArray = stringValCryptoConverter.entityAttributeToByteArray(EncryptedString("bob"))
+        val entityAttributeToByteArray = stringValCryptoWritingConverter.entityAttributeToByteArray(EncryptedString("bob"))
 
         assertThat(entityAttributeToByteArray).isEqualTo(byteArray)
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseServiceTest.kt
@@ -63,7 +63,7 @@ class JournalhendelseServiceTest {
         clearAllMocks(this)
 
         every {
-            mockHendelseloggRepository.save(any())
+            mockHendelseloggRepository.insert(any())
         } returns Hendelseslogg(offset = 1L, hendelseId = "")
 
         every {
@@ -175,7 +175,7 @@ class JournalhendelseServiceTest {
         }
 
         verify(exactly = 1) {
-            mockHendelseloggRepository.save(any())
+            mockHendelseloggRepository.insert(any())
         }
     }
 
@@ -187,7 +187,7 @@ class JournalhendelseServiceTest {
         service.prosesserNyHendelse(journalføringhendelseRecord, OFFSET)
 
         verify(exactly = 0) {
-            mockHendelseloggRepository.save(any())
+            mockHendelseloggRepository.insert(any())
         }
     }
 
@@ -204,7 +204,7 @@ class JournalhendelseServiceTest {
 
         val slot = slot<Hendelseslogg>()
         verify(exactly = 1) {
-            mockHendelseloggRepository.save(capture(slot))
+            mockHendelseloggRepository.insert(capture(slot))
         }
 
         assertThat(slot.captured).isNotNull

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/DokumentasjonsbehovRepositoryTest.kt
@@ -24,11 +24,11 @@ internal class DokumentasjonsbehovRepositoryTest : IntegrasjonSpringRunnerTest()
     @Test
     internal fun `lagre og hent dokumentasjonsbehov`() {
 
-        val søknad = søknadRepository.save(Søknad(søknadJson = EncryptedString("bob"),
-                                                  fnr = "ded",
-                                                  dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD))
+        val søknad = søknadRepository.insert(Søknad(søknadJson = EncryptedString("bob"),
+                                                    fnr = "ded",
+                                                    dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD))
 
-        dokumentasjonsbehovRepository.save(Dokumentasjonsbehov(søknad.id, "data"))
+        dokumentasjonsbehovRepository.insert(Dokumentasjonsbehov(søknad.id, "data"))
         val dokumentasjonsbehov = dokumentasjonsbehovRepository.findByIdOrNull(søknad.id)
         assertThat(dokumentasjonsbehov).isNotNull
         assertThat(dokumentasjonsbehov?.data).isEqualTo("data")

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/EttersendingRepositoryTest.kt
@@ -34,11 +34,12 @@ internal class EttersendingRepositoryTest : IntegrasjonSpringRunnerTest() {
 
         val ettersendelseDto = EttersendelseDto(
                 listOf(dokumentasjonsbehov), personIdent = personIdent)
-        val ettersending = ettersendingRepository.save(EttersendingMapper.fromDto(StønadType.OVERGANGSSTØNAD, ettersendelseDto))
+        val ettersending = ettersendingRepository.insert(EttersendingMapper.fromDto(StønadType.OVERGANGSSTØNAD, ettersendelseDto))
 
 
         assertThat(ettersendingRepository.count()).isEqualTo(1)
-        assertThat(objectMapper.readValue(ettersending.ettersendingJson.data, EttersendelseDto::class.java)).usingRecursiveComparison()
+        assertThat(objectMapper.readValue(ettersending.ettersendingJson.data, EttersendelseDto::class.java))
+                .usingRecursiveComparison()
                 .isEqualTo(ettersendelseDto)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/HendelsesloggRepositoryTest.kt
@@ -3,10 +3,8 @@ package no.nav.familie.ef.mottak.repository
 import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.repository.domain.Hendelseslogg
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.dao.EmptyResultDataAccessException
 import java.util.UUID
 
 internal class HendelsesloggRepositoryTest : IntegrasjonSpringRunnerTest() {
@@ -16,10 +14,10 @@ internal class HendelsesloggRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `skal hente max av kafka_offset`() {
-        hendelsesloggRepository.save(Hendelseslogg(50, UUID.randomUUID().toString()))
+        hendelsesloggRepository.insert(Hendelseslogg(50, UUID.randomUUID().toString()))
         val hendelseId = UUID.randomUUID().toString()
-        hendelsesloggRepository.save(Hendelseslogg(200, hendelseId))
-        hendelsesloggRepository.save(Hendelseslogg(100, UUID.randomUUID().toString()))
+        hendelsesloggRepository.insert(Hendelseslogg(200, hendelseId))
+        hendelsesloggRepository.insert(Hendelseslogg(100, UUID.randomUUID().toString()))
         assertThat(hendelsesloggRepository.existsByHendelseId(hendelseId)).isTrue
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/StatistikkRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/StatistikkRepositoryTest.kt
@@ -20,8 +20,8 @@ internal class StatistikkRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `søknader - to søknader av overgangsstønad`() {
-        søknadRepository.save(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
-        søknadRepository.save(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
+        søknadRepository.insert(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
+        søknadRepository.insert(Søknad(søknadJson = EncryptedString("{}"), dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD, fnr = ""))
         val statistikk = statistikkRepository.antallSøknaderPerDokumentType()
         assertThat(statistikk).hasSize(1)
         assertThat(statistikk[0].antall).isEqualTo(2)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepositoryTest.kt
@@ -19,9 +19,9 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
     @Test
     internal fun `findFirstByTaskOpprettetIsFalse returnerer én soknad med taskOpprettet false`() {
 
-        søknadRepository.save(søknad())
-        søknadRepository.save(søknad())
-        søknadRepository.save(søknad(taskOpprettet = true))
+        søknadRepository.insert(søknad())
+        søknadRepository.insert(søknad())
+        søknadRepository.insert(søknad(taskOpprettet = true))
 
         val soknadUtenTask = søknadRepository.findFirstByTaskOpprettetIsFalse()
 
@@ -30,7 +30,7 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `findFirstByTaskOpprettetIsFalse takler null result`() {
-        søknadRepository.save(søknad(taskOpprettet = true))
+        søknadRepository.insert(søknad(taskOpprettet = true))
 
         val soknadUtenTask = søknadRepository.findFirstByTaskOpprettetIsFalse()
 
@@ -39,7 +39,7 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `findByJournalpostId skal returnere søknad`() {
-        søknadRepository.save(søknad(taskOpprettet = true, journalpostId = "123"))
+        søknadRepository.insert(søknad(taskOpprettet = true, journalpostId = "123"))
 
         val soknadUtenTask = søknadRepository.findByJournalpostId("123")
         assertThat(soknadUtenTask).isNotNull
@@ -47,7 +47,7 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `findByJournalpostId skal returnere null`() {
-        søknadRepository.save(søknad(taskOpprettet = true))
+        søknadRepository.insert(søknad(taskOpprettet = true))
         val soknadUtenTask = søknadRepository.findByJournalpostId("123")
         assertThat(soknadUtenTask).isNull()
     }
@@ -56,15 +56,15 @@ internal class SøknadRepositoryTest : IntegrasjonSpringRunnerTest() {
     internal fun `findAllByFnr returnerer flere søknader`() {
         val ident = "12345678"
 
-        val søknadOvergangsstønad = søknadRepository.save(Søknad(søknadJson = EncryptedString("kåre"),
-                                                                 fnr = ident,
-                                                                 dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
-                                                                 taskOpprettet = true))
+        val søknadOvergangsstønad = søknadRepository.insert(Søknad(søknadJson = EncryptedString("kåre"),
+                                                                   fnr = ident,
+                                                                   dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
+                                                                   taskOpprettet = true))
 
-        val søknadBarnetilsyn = søknadRepository.save(Søknad(søknadJson = EncryptedString("kåre"),
-                                                             fnr = ident,
-                                                             dokumenttype = DOKUMENTTYPE_BARNETILSYN,
-                                                             taskOpprettet = true))
+        val søknadBarnetilsyn = søknadRepository.insert(Søknad(søknadJson = EncryptedString("kåre"),
+                                                               fnr = ident,
+                                                               dokumenttype = DOKUMENTTYPE_BARNETILSYN,
+                                                               taskOpprettet = true))
 
         val søknader = søknadRepository.findAllByFnr(ident)
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/repository/VedleggRepositoryTest.kt
@@ -7,10 +7,8 @@ import no.nav.familie.ef.mottak.repository.VedleggRepository
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Vedlegg
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.TransactionSystemException
 import java.util.UUID
 
 internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
@@ -21,8 +19,8 @@ internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `findBySøknadId returnerer vedlegg`() {
-        val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
+        val søknadId = søknadRepository.insert(søknad()).id
+        vedleggRepository.insert(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
 
         assertThat(vedleggRepository.findBySøknadId(søknadId)).hasSize(1)
         assertThat(vedleggRepository.findBySøknadId("finnes ikke")).isEmpty()
@@ -30,29 +28,11 @@ internal class VedleggRepositoryTest : IntegrasjonSpringRunnerTest() {
 
     @Test
     internal fun `findTitlerBySøknadId returnerer titler`() {
-        val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
+        val søknadId = søknadRepository.insert(søknad()).id
+        vedleggRepository.insert(Vedlegg(UUID.randomUUID(), søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
 
         val vedlegg = vedleggRepository.findTitlerBySøknadId(søknadId)
 
         assertThat(vedlegg).hasSize(1)
-    }
-
-    @Test
-    internal fun `det skal ikke være mulig å oppdatere et vedlegg med ny søknadId`() {
-        val vedleggId = UUID.randomUUID()
-        val søknadId = søknadRepository.save(søknad()).id
-        vedleggRepository.save(Vedlegg(vedleggId, søknadId, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
-
-        val søknad2Id = søknadRepository.save(søknad()).id
-        assertThat(catchThrowable {
-            vedleggRepository.save(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", EncryptedFile(byteArrayOf(12))))
-        }).isInstanceOf(TransactionSystemException::class.java)
-                .hasRootCauseMessage("Det går ikke å oppdatere vedlegg")
-
-        assertThat(catchThrowable {
-            vedleggRepository.saveAll(listOf(Vedlegg(vedleggId, søknad2Id, "navn", "tittel1", EncryptedFile(byteArrayOf(12)))))
-        }).isInstanceOf(TransactionSystemException::class.java)
-                .hasRootCauseMessage("Det går ikke å oppdatere vedlegg")
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
@@ -64,7 +64,7 @@ internal class EttersendingServiceTest {
         every { dokumentClient.hentVedlegg(vedlegg1.id) } returns dokument1
         every { dokumentClient.hentVedlegg(vedlegg2.id) } returns dokument2
         every {
-            ettersendingVedleggRepository.saveAll(capture(ettersendingVedleggSlot))
+            ettersendingVedleggRepository.insertAll(capture(ettersendingVedleggSlot))
         } answers { ettersendingVedleggSlot.captured }
         every {
             hint(Ettersending::class)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
@@ -68,7 +68,7 @@ internal class EttersendingServiceTest {
         } answers { ettersendingVedleggSlot.captured }
         every {
             hint(Ettersending::class)
-            ettersendingRepository.save(capture(ettersendingSlot))
+            ettersendingRepository.insert(capture(ettersendingSlot))
         } answers { ettersendingSlot.captured }
 
         ettersendingService.mottaEttersending(mapOf(StønadType.OVERGANGSSTØNAD to EttersendelseDto(listOf(dokumentasjonsbehov1,

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveServiceTest.kt
@@ -110,9 +110,10 @@ class JournalføringsoppgaveServiceTest {
 
         every { journalpost.journalstatus } returns Journalstatus.MOTTATT
         every { journalpost.kanal } returns "NAV_NO"
-        every { mockEttersendingRepository.findByJournalpostId(any()) } returns Ettersending(ettersendingJson = EncryptedString(""),
-                                                                                             stønadType = "OVERGANGSSTØNAD",
-                                                                                             fnr = "")
+        every { mockEttersendingRepository.findByJournalpostId(any()) } returns
+                Ettersending(ettersendingJson = EncryptedString(""),
+                             stønadType = "OVERGANGSSTØNAD",
+                             fnr = "")
 
         service.lagEksternJournalføringTask(journalpost)
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -12,8 +12,8 @@ import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.mapper.BehandlesAvApplikasjon
 import no.nav.familie.ef.mottak.mapper.OpprettOppgaveMapper
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.IOTestUtil
-import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
+import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.ef.felles.StønadType

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/PdfServiceTest.kt
@@ -100,7 +100,7 @@ internal class PdfServiceTest {
         // Then
         verify(exactly = 1) { vedleggRepository.findTitlerBySøknadId(any()) }
         verify(exactly = 1) {
-            søknadRepository.saveAndFlush(slot.captured)
+            søknadRepository.update(slot.captured)
         }
     }
 
@@ -124,7 +124,7 @@ internal class PdfServiceTest {
 
     private fun capturePdfAddedToSøknad(slot: CapturingSlot<Søknad>) {
         every {
-            søknadRepository.saveAndFlush(capture(slot))
+            søknadRepository.update(capture(slot))
         } answers {
             slot.captured
         }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskMetricServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskMetricServiceTest.kt
@@ -23,13 +23,13 @@ internal class TaskMetricServiceTest : IntegrasjonSpringRunnerTest() {
     @Test
     internal fun `henting av metrics går fint`() {
         taskRepository.deleteAll()
-        søknadRepository.save(søknad())
+        søknadRepository.insert(søknad())
         //oppretter 2 søknader som har opprettet tid nå som ikke skal vises
-        søknadRepository.save(søknad(LocalDateTime.now()))
-        søknadRepository.save(søknad(LocalDateTime.now()))
+        søknadRepository.insert(søknad(LocalDateTime.now()))
+        søknadRepository.insert(søknad(LocalDateTime.now()))
         //oppretter 2 søknader som har taskOpprettet = true som ikke skal vises
-        søknadRepository.save(søknad(taskOpprettet = true))
-        søknadRepository.save(søknad(taskOpprettet = true))
+        søknadRepository.insert(søknad(taskOpprettet = true))
+        søknadRepository.insert(søknad(taskOpprettet = true))
 
         taskRepository.save(Task("test2", UUID.randomUUID().toString()).copy(status = Status.FEILET))
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
@@ -27,7 +27,7 @@ internal class TaskProsesseringServiceTest {
         val soknadSlot = slot<Søknad>()
         every { taskRepository.save(capture(taskSlot)) }
                 .answers { taskSlot.captured }
-        every { søknadRepository.save(capture(soknadSlot)) }
+        every { søknadRepository.insert(capture(soknadSlot)) }
                 .answers { soknadSlot.captured }
 
         scheduledEventService.startTaskProsessering(soknad)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
@@ -27,7 +27,7 @@ internal class TaskProsesseringServiceTest {
         val soknadSlot = slot<Søknad>()
         every { taskRepository.save(capture(taskSlot)) }
                 .answers { taskSlot.captured }
-        every { søknadRepository.insert(capture(soknadSlot)) }
+        every { søknadRepository.update(capture(soknadSlot)) }
                 .answers { soknadSlot.captured }
 
         scheduledEventService.startTaskProsessering(soknad)

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/ArkiverEttersendingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/ArkiverEttersendingTaskTest.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ef.mottak.task
+
+import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
+import no.nav.familie.ef.mottak.repository.util.findByIdOrThrow
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.internal.TaskWorker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Vi oppdaterer task.metadata i flere tasker, denne sjekker att det er mulig, sånn att ikke blir endringer i prosessering
+ * Hvis denne brekker må man vurdere hur de ellers burde oppdateres
+ */
+internal class TaskTest : IntegrasjonSpringRunnerTest() {
+
+    @Suppress("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired private lateinit var taskWorker: TaskWorker
+
+    @Autowired private lateinit var taskRepository: TaskRepository
+
+    @Test
+    internal fun `skal oppdatere task med journalpostId etter att doTask er kjørt, i doActualWork, hvis ikke får man optimistic lock failure`() {
+        val task = taskRepository.save(Task(TEST_TASK_TYPE, UUID.randomUUID().toString()))
+
+        taskWorker.markerPlukket(task.id)
+        taskWorker.doActualWork(task.id)
+
+        val oppdatertTask = taskRepository.findByIdOrThrow(task.id)
+        assertThat(task.metadata["journalpostId"]).isNull()
+        assertThat(oppdatertTask.metadata["journalpostId"]).isEqualTo("Nytt verdi")
+    }
+}
+
+private const val TEST_TASK_TYPE = "TestTask"
+
+@Service
+@TaskStepBeskrivelse(taskStepType = TEST_TASK_TYPE, beskrivelse = "")
+class TestTask : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        logger.info("Håndterer task id=${task.id}")
+        task.metadata.apply {
+            this["journalpostId"] = "Nytt verdi"
+        }
+    }
+
+}

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/LagBehandleSakOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/LagBehandleSakOppgaveTaskTest.kt
@@ -41,20 +41,18 @@ internal class LagBehandleSakOppgaveTaskTest {
 
     @Test
     internal fun `skal lage behandle-sak-oppgave dersom det ikke finnes infotrygdsak fra før`() {
-        val taskSlot = slot<Task>()
-
         every { sakService.finnesIkkeIInfotrygd(any()) } returns true
         every { søknadService.get("123L") } returns søknad(journalpostId = JOURNALPOST_DIGITALSØKNAD)
         every { integrasjonerClient.hentJournalpost(any()) } returns mockJournalpost()
         every { oppgaveService.lagBehandleSakOppgave(any(), BehandlesAvApplikasjon.INFOTRYGD) } returns 99L
-        every { taskRepository.save(capture(taskSlot)) }.answers { taskSlot.captured }
         every { saksbehandlingClient.finnesBehandlingForPerson(any(), any()) } returns false
 
-        lagBehandleSakOppgaveTask.doTask(Task(type = "", payload = "123L", properties = Properties()))
+        val task = Task(type = "", payload = "123L", properties = Properties())
+        lagBehandleSakOppgaveTask.doTask(task)
         verify(exactly = 1) {
             oppgaveService.lagBehandleSakOppgave(any(), BehandlesAvApplikasjon.INFOTRYGD)
         }
-        assertThat(taskSlot.captured.metadata[LagBehandleSakOppgaveTask.behandleSakOppgaveIdKey]).isEqualTo("99")
+        assertThat(task.metadata[LagBehandleSakOppgaveTask.behandleSakOppgaveIdKey]).isEqualTo("99")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTaskTest.kt
@@ -47,7 +47,7 @@ internal class OpprettSakTaskTest {
         } returns soknad
         every { dateTimeService.now() } returns LocalDateTime.of(2020, 1, 1, 12, 0)
         every {
-            søknadRepository.insert(capture(soknadSlot))
+            søknadRepository.update(capture(soknadSlot))
         } returns soknad
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/OpprettSakTaskTest.kt
@@ -47,7 +47,7 @@ internal class OpprettSakTaskTest {
         } returns soknad
         every { dateTimeService.now() } returns LocalDateTime.of(2020, 1, 1, 12, 0)
         every {
-            søknadRepository.save(capture(soknadSlot))
+            søknadRepository.insert(capture(soknadSlot))
         } returns soknad
     }
 


### PR DESCRIPTION
Fortsetting på 
* https://github.com/navikt/familie-ef-mottak/pull/724

* Notere at taskRepository.save er fjernet i tasks, der den er brukt for å oppdatere task. Dette er ikke mulig med spring-jdbc pga `@Version`, se https://github.com/navikt/familie-ef-mottak/commit/42a6fc0f479f879b6c84f85986359c4c0a6d3f84 for mer info
* `AbstractCryptoConverter` er splittet opp i en writer og en reader då man i spring-jdbc registerer converters separat og ikke som annotasjon i domeneobjektet


https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8357