### PR TITLE
Automatisk journalføring taskimpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>1.20220610091422_f8b17ff</prosessering.version>
         <confluent.version>7.2.1</confluent.version>
         <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>2.0_20220819134825_6678be2</kontrakter.version>
+        <kontrakter.version>2.0_20220902124350_714a1f2</kontrakter.version>
         <token-validation.version>2.1.3</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
@@ -1,9 +1,12 @@
 package no.nav.familie.ef.mottak.integration
 
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringRequest
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -24,9 +27,23 @@ class SaksbehandlingClient(
 
     fun kanOppretteFørstegangsbehandling(personIdent: String, stønadType: StønadType): Boolean {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri)
-            .pathSegment("api/ekstern/behandling/kan-opprette-forstegangsbehandling")
+            .pathSegment("/api/ekstern/automatisk-journalforing/kan-opprette-forstegangsbehandling")
             .queryParam("type", stønadType.name)
         val response = postForEntity<Ressurs<Boolean>>(uriComponentsBuilder.build().toUri(), PersonIdent(personIdent))
         return response.data ?: error("Kall mot ef-sak feilet melding=${response.melding}")
+    }
+
+    fun lagFørstegangsbehandlingOgBehandleSakOppgave(
+        automatiskJournalføringRequest: AutomatiskJournalføringRequest
+    ): AutomatiskJournalføringResponse {
+
+        val sendInnUri = UriComponentsBuilder.fromUri(uri)
+            .pathSegment("api/ekstern/automatisk-journalforing/journalfor")
+            .build()
+            .toUri()
+
+        val response =
+            postForEntity<Ressurs<AutomatiskJournalføringResponse>>(sendInnUri, automatiskJournalføringRequest)
+        return response.getDataOrThrow()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
@@ -33,7 +33,7 @@ class SaksbehandlingClient(
         return response.data ?: error("Kall mot ef-sak feilet melding=${response.melding}")
     }
 
-    fun lagFørstegangsbehandlingOgBehandleSakOppgave(
+    fun journalførAutomatisk(
         automatiskJournalføringRequest: AutomatiskJournalføringRequest
     ): AutomatiskJournalføringResponse {
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
@@ -8,7 +8,6 @@ import no.nav.familie.prosessering.domene.TaskRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AutomatiskJournalføringService(
@@ -20,8 +19,7 @@ class AutomatiskJournalføringService(
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-    @Transactional
-    fun lagFørstegangsbehandlingOgBehandleSakOppgave(
+    fun journalførAutomatisk(
         personIdent: String,
         journalpostId: String,
         stønadstype: StønadType
@@ -32,9 +30,9 @@ class AutomatiskJournalføringService(
             stønadstype = stønadstype
         )
         try {
-            val lagFørstegangsbehandlingOgBehandleSakOppgave =
-                saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(arkiverDokumentRequest)
-            infoLog(journalpostId, lagFørstegangsbehandlingOgBehandleSakOppgave)
+            val respons =
+                saksbehandlingClient.journalførAutomatisk(arkiverDokumentRequest)
+            infoLog(journalpostId, respons)
         } catch (e: Exception) {
             logger.error("Feil ved prosessering av automatisk journalhendelser for $stønadstype: journalpostId: $journalpostId, fallback => manuell")
             secureLogger.error("Feil ved prosessering av automatisk journalhendelser", e)
@@ -45,13 +43,13 @@ class AutomatiskJournalføringService(
 
     private fun infoLog(
         journalpostId: String,
-        lagFørstegangsbehandlingOgBehandleSakOppgave: AutomatiskJournalføringResponse
+        automatiskJournalføringResponse: AutomatiskJournalføringResponse
     ) {
         logger.info(
             "Automatisk journalført:$journalpostId: " +
-                "behandlingId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.behandlingId}, " +
-                "fagsakId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.fagsakId}, " +
-                "behandleSakOppgaveId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.behandleSakOppgaveId}"
+                "behandlingId: ${automatiskJournalføringResponse.behandlingId}, " +
+                "fagsakId: ${automatiskJournalføringResponse.fagsakId}, " +
+                "behandleSakOppgaveId: ${automatiskJournalføringResponse.behandleSakOppgaveId}"
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
@@ -5,6 +5,8 @@ import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringReque
 import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.domene.TaskRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,17 +17,41 @@ class AutomatiskJournalføringService(
     val taskRepository: TaskRepository
 ) {
 
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
     @Transactional
     fun lagFørstegangsbehandlingOgBehandleSakOppgave(
         personIdent: String,
         journalpostId: String,
         stønadstype: StønadType
-    ): AutomatiskJournalføringResponse {
+    ): Boolean {
         val arkiverDokumentRequest = AutomatiskJournalføringRequest(
             personIdent = personIdent,
             journalpostId = journalpostId,
             stønadstype = stønadstype
         )
-        return saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(arkiverDokumentRequest)
+        try {
+            val lagFørstegangsbehandlingOgBehandleSakOppgave =
+                saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(arkiverDokumentRequest)
+            infoLog(journalpostId, lagFørstegangsbehandlingOgBehandleSakOppgave)
+        } catch (e: Exception) {
+            logger.error("Feil ved prosessering av automatisk journalhendelser for $stønadstype: journalpostId: $journalpostId, fallback => manuell")
+            secureLogger.error("Feil ved prosessering av automatisk journalhendelser", e)
+            return false
+        }
+        return true
+    }
+
+    private fun infoLog(
+        journalpostId: String,
+        lagFørstegangsbehandlingOgBehandleSakOppgave: AutomatiskJournalføringResponse
+    ) {
+        logger.info(
+            "Automatisk journalført:$journalpostId: " +
+                "behandlingId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.behandlingId}, " +
+                "fagsakId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.fagsakId}, " +
+                "behandleSakOppgaveId: ${lagFørstegangsbehandlingOgBehandleSakOppgave.behandleSakOppgaveId}"
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.mottak.service
+
+import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringRequest
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AutomatiskJournalføringService(
+    val saksbehandlingClient: SaksbehandlingClient,
+    val søknadService: SøknadService,
+    val taskRepository: TaskRepository
+) {
+
+    @Transactional
+    fun lagFørstegangsbehandlingOgBehandleSakOppgave(
+        personIdent: String,
+        journalpostId: String,
+        stønadstype: StønadType
+    ): AutomatiskJournalføringResponse {
+        val arkiverDokumentRequest = AutomatiskJournalføringRequest(
+            personIdent = personIdent,
+            journalpostId = journalpostId,
+            stønadstype = stønadstype
+        )
+        return saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(arkiverDokumentRequest)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringService.kt
@@ -34,7 +34,7 @@ class AutomatiskJournalføringService(
                 saksbehandlingClient.journalførAutomatisk(arkiverDokumentRequest)
             infoLog(journalpostId, respons)
         } catch (e: Exception) {
-            logger.error("Feil ved prosessering av automatisk journalhendelser for $stønadstype: journalpostId: $journalpostId, fallback => manuell")
+            logger.error("Feil ved prosessering av automatisk journalhendelser for $stønadstype: journalpostId: $journalpostId")
             secureLogger.error("Feil ved prosessering av automatisk journalhendelser", e)
             return false
         }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
@@ -1,19 +1,66 @@
 package no.nav.familie.ef.mottak.task
 
+import no.nav.familie.ef.mottak.repository.domain.Søknad
+import no.nav.familie.ef.mottak.service.AutomatiskJournalføringService
+import no.nav.familie.ef.mottak.service.SøknadService
+import no.nav.familie.ef.mottak.util.dokumenttypeTilStønadType
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 @TaskStepBeskrivelse(taskStepType = AutomatiskJournalførTask.TYPE, beskrivelse = "Automatisk journalfør")
-class AutomatiskJournalførTask : AsyncTaskStep {
+class AutomatiskJournalførTask(
+    val søknadService: SøknadService,
+    val taskRepository: TaskRepository,
+    val automatiskJournalføringService: AutomatiskJournalføringService
+) :
+    AsyncTaskStep {
 
+    @Transactional
     override fun doTask(task: Task) {
-        TODO("Not yet implemented")
+        val logger: Logger = LoggerFactory.getLogger(this::class.java)
+        val søknad: Søknad = søknadService.get(task.payload)
+        val stønadstype: StønadType =
+            dokumenttypeTilStønadType(søknad.dokumenttype) ?: error("Må ha stønadstype for å automatisk journalføre")
+        val journalpostId = task.metadata["journalpostId"].toString()
+
+        try {
+            val response = automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+                personIdent = søknad.fnr,
+                journalpostId = journalpostId,
+                stønadstype = stønadstype
+            )
+            logger.info(
+                "Automatisk journalført:$journalpostId: " +
+                    "behandlingId: ${response.behandlingId}, " +
+                    "fagsakId: ${response.fagsakId}, " +
+                    "behandleSakOppgaveId: ${response.behandleSakOppgaveId}"
+            )
+        } catch (e: Exception) {
+            logger.warn("Feil ved prosessering av automatisk journalhendelser for $stønadstype: journalpostId: $journalpostId, fallback => manuell")
+            val nesteFallbackTask = TaskType(TYPE).nesteFallbackTask()
+            val fallback = Task(nesteFallbackTask, task.payload, task.metadata)
+            taskRepository.save(fallback)
+        }
     }
 
     companion object {
         const val TYPE = "automatiskJournalfør"
     }
 }
+
+// TODO oppdatere metadata på denne tasken, eller en "resultatTask" hvis alt ok? Eller bare logge?
+// task.metadata.apply {
+//     this["behandleSakOppgaveId"] = response.behandleSakOppgaveId
+//     this["behandlingId"] = response.behandlingId
+//     this["fagsakId"] = response.fagsakId
+// }
+//  taskRepository.save(task)
+// val feilCounter: Counter = Metrics.counter("alene.med.barn.automatiskjournalføring.feilet")

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
@@ -10,7 +10,6 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 @TaskStepBeskrivelse(taskStepType = AutomatiskJournalførTask.TYPE, beskrivelse = "Automatisk journalfør")
@@ -21,7 +20,6 @@ class AutomatiskJournalførTask(
 ) :
     AsyncTaskStep {
 
-    @Transactional
     override fun doTask(task: Task) {
         val søknad: Søknad = søknadService.get(task.payload)
         val stønadstype: StønadType =
@@ -29,7 +27,7 @@ class AutomatiskJournalførTask(
         val journalpostId = task.metadata["journalpostId"].toString()
 
         val automatiskJournalføringFullført =
-            automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+            automatiskJournalføringService.journalførAutomatisk(
                 personIdent = søknad.fnr,
                 journalpostId = journalpostId,
                 stønadstype = stønadstype

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
@@ -9,6 +9,8 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -19,6 +21,8 @@ class AutomatiskJournalførTask(
     val automatiskJournalføringService: AutomatiskJournalføringService
 ) :
     AsyncTaskStep {
+
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun doTask(task: Task) {
         val søknad: Søknad = søknadService.get(task.payload)
@@ -34,6 +38,7 @@ class AutomatiskJournalførTask(
             )
 
         if (!automatiskJournalføringFullført) {
+            logger.warn("Kunne ikke automatisk journalføre $journalpostId - fortsetter derfor på manuell journalføringsflyt")
             val nesteFallbackTaskType = manuellJournalføringFlyt().first().type
             val fallback = Task(nesteFallbackTaskType, task.payload, task.metadata)
             taskRepository.save(fallback)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/TaskFlyt.kt
@@ -15,6 +15,12 @@ fun automatiskJournalføringFlyt() = listOf(
     TaskType(AutomatiskJournalførTask.TYPE)
 )
 
+val fallbacks = mapOf(
+    TaskType(AutomatiskJournalførTask.TYPE) to LagJournalføringsoppgaveTask.TYPE,
+)
+
+fun TaskType.nesteFallbackTask() = fallbacks[this] ?: error("Finner ikke fallback til $this")
+
 fun ettersendingflyt() = listOf(
     TaskType(LagEttersendingPdfTask.TYPE),
     TaskType(ArkiverEttersendingTask.TYPE),

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/TaskFlyt.kt
@@ -15,12 +15,6 @@ fun automatiskJournalføringFlyt() = listOf(
     TaskType(AutomatiskJournalførTask.TYPE)
 )
 
-val fallbacks = mapOf(
-    TaskType(AutomatiskJournalførTask.TYPE) to LagJournalføringsoppgaveTask.TYPE,
-)
-
-fun TaskType.nesteFallbackTask() = fallbacks[this] ?: error("Finner ikke fallback til $this")
-
 fun ettersendingflyt() = listOf(
     TaskType(LagEttersendingPdfTask.TYPE),
     TaskType(ArkiverEttersendingTask.TYPE),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ef.mottak.service
+
+import io.mockk.mockk
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.junit.jupiter.api.Test
+
+internal class AutomatiskJournalføringServiceTest {
+
+    private val automatiskJournalføringService =
+        AutomatiskJournalføringService(
+            taskRepository = mockk(),
+            søknadService = mockk(),
+            saksbehandlingClient = mockk()
+        )
+
+    @Test
+    internal fun `Skal gjøre noe `() {
+        // TODO implementer god test
+        automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+            personIdent = "",
+            journalpostId = "",
+            stønadstype = StønadType.OVERGANGSSTØNAD
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
@@ -1,25 +1,60 @@
 package no.nav.familie.ef.mottak.service
 
+import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 internal class AutomatiskJournalføringServiceTest {
 
+    private val saksbehandlingClient = mockk<SaksbehandlingClient>()
     private val automatiskJournalføringService =
         AutomatiskJournalføringService(
             taskRepository = mockk(),
             søknadService = mockk(),
-            saksbehandlingClient = mockk()
+            saksbehandlingClient = saksbehandlingClient
         )
 
+    private val automatiskJournalføringResponse = AutomatiskJournalføringResponse(
+        fagsakId = UUID.randomUUID(),
+        behandlingId = UUID.randomUUID(),
+        behandleSakOppgaveId = 0
+    )
+
     @Test
-    internal fun `Skal gjøre noe `() {
-        // TODO implementer god test
-        automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
-            personIdent = "",
-            journalpostId = "",
-            stønadstype = StønadType.OVERGANGSSTØNAD
-        )
+    internal fun `Skal returnere true når journalføring i ef-sak går bra `() {
+
+        every {
+            saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(any())
+        } returns automatiskJournalføringResponse
+
+        assertTrue {
+            automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+                personIdent = "",
+                journalpostId = "",
+                stønadstype = StønadType.OVERGANGSSTØNAD
+            )
+        }
+    }
+
+    @Test
+    internal fun `Skal returnere false når journalføring i ef-sak går bra `() {
+
+        every {
+            saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(any())
+        } throws RuntimeException("Feil")
+
+        assertFalse {
+            automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+                personIdent = "",
+                journalpostId = "",
+                stønadstype = StønadType.OVERGANGSSTØNAD
+            )
+        }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
@@ -30,11 +30,11 @@ internal class AutomatiskJournalføringServiceTest {
     internal fun `Skal returnere true når journalføring i ef-sak går bra `() {
 
         every {
-            saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(any())
+            saksbehandlingClient.journalførAutomatisk(any())
         } returns automatiskJournalføringResponse
 
         assertTrue {
-            automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+            automatiskJournalføringService.journalførAutomatisk(
                 personIdent = "",
                 journalpostId = "",
                 stønadstype = StønadType.OVERGANGSSTØNAD
@@ -46,11 +46,11 @@ internal class AutomatiskJournalføringServiceTest {
     internal fun `Skal returnere false når journalføring i ef-sak går bra `() {
 
         every {
-            saksbehandlingClient.lagFørstegangsbehandlingOgBehandleSakOppgave(any())
+            saksbehandlingClient.journalførAutomatisk(any())
         } throws RuntimeException("Feil")
 
         assertFalse {
-            automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+            automatiskJournalføringService.journalførAutomatisk(
                 personIdent = "",
                 journalpostId = "",
                 stønadstype = StønadType.OVERGANGSSTØNAD

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
@@ -60,7 +60,7 @@ internal class AutomatiskJournalførTaskTest {
     internal fun `Skal bruke fallback manuell journalføring dersom vi får exception når vi kaller på ef-sak`() {
         val taskSlot = slot<Task>()
         every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
-        every { automatiskJournalføring() } throws RuntimeException("Feil")
+        every { automatiskJournalføring() } returns false
 
         automatiskJournalførTask.doTask(task)
 
@@ -74,7 +74,7 @@ internal class AutomatiskJournalførTaskTest {
             behandlingId = UUID.randomUUID(),
             behandleSakOppgaveId = 0
         )
-        every { automatiskJournalføring() } returns response
+        every { automatiskJournalføring() } returns true
         automatiskJournalførTask.doTask(task)
         verify(exactly = 0) { taskRepository.save(any()) }
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
@@ -80,7 +80,7 @@ internal class AutomatiskJournalførTaskTest {
     }
 
     private fun MockKMatcherScope.automatiskJournalføring() =
-        automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+        automatiskJournalføringService.journalførAutomatisk(
             any(),
             any(),
             any()

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
@@ -1,0 +1,88 @@
+package no.nav.familie.ef.mottak.task
+
+import io.mockk.MockKMatcherScope
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
+import no.nav.familie.ef.mottak.encryption.EncryptedString
+import no.nav.familie.ef.mottak.repository.domain.Søknad
+import no.nav.familie.ef.mottak.service.AutomatiskJournalføringService
+import no.nav.familie.ef.mottak.service.SøknadService
+import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.util.FnrGenerator
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Properties
+import java.util.UUID
+
+internal class AutomatiskJournalførTaskTest {
+
+    val automatiskJournalføringService: AutomatiskJournalføringService = mockk()
+    val søknadService: SøknadService = mockk()
+    val taskRepository: TaskRepository = mockk()
+
+    val automatiskJournalførTask = AutomatiskJournalførTask(
+        taskRepository = taskRepository,
+        automatiskJournalføringService = automatiskJournalføringService,
+        søknadService = søknadService
+    )
+
+    private val task: Task
+        get() {
+            val task =
+                Task(type = AutomatiskJournalførTask.TYPE, payload = overgangsstønadSøknadId, properties = Properties())
+            task.metadata.apply {
+                this["journalpostId"] = "123"
+            }
+            return task
+        }
+
+    private val overgangsstønadSøknadId = "123L"
+
+    @BeforeEach
+    internal fun setUp() {
+        every {
+            søknadService.get(overgangsstønadSøknadId)
+        } returns Søknad(
+            søknadJson = EncryptedString(""),
+            dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
+            journalpostId = "1234",
+            fnr = FnrGenerator.generer()
+        )
+    }
+
+    @Test
+    internal fun `Skal bruke fallback manuell journalføring dersom vi får exception når vi kaller på ef-sak`() {
+        val taskSlot = slot<Task>()
+        every { taskRepository.save(capture(taskSlot)) } answers { taskSlot.captured }
+        every { automatiskJournalføring() } throws RuntimeException("Feil")
+
+        automatiskJournalførTask.doTask(task)
+
+        Assertions.assertThat(taskSlot.captured.type).isEqualTo(manuellJournalføringFlyt().first().type)
+    }
+
+    @Test
+    internal fun `Skal ikke bruke fallback til manuell journalføring når alt er ok`() {
+        val response = AutomatiskJournalføringResponse(
+            fagsakId = UUID.randomUUID(),
+            behandlingId = UUID.randomUUID(),
+            behandleSakOppgaveId = 0
+        )
+        every { automatiskJournalføring() } returns response
+        automatiskJournalførTask.doTask(task)
+        verify(exactly = 0) { taskRepository.save(any()) }
+    }
+
+    private fun MockKMatcherScope.automatiskJournalføring() =
+        automatiskJournalføringService.lagFørstegangsbehandlingOgBehandleSakOppgave(
+            any(),
+            any(),
+            any()
+        )
+}


### PR DESCRIPTION
Vil automatisk journalføre digitale søknader - opprette førstegangs-søknad-behandling og behandle sak oppgave.

Dersom "noe" går galt når vi journalfører bruker vi fallback "manuell" journalføring. 

Valg vi har tatt: 
Vi er defensive - alle feil, eller ressurs uten data vil gjøre at vi går tilbake til manuell flyt.
 

