### PR TITLE
skal kunne sende sms-påminnelse til bruker ved manglende dokumentasjo…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/TestSmsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/TestSmsController.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ef.mottak.api
+
+import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
+import no.nav.familie.ef.mottak.config.EttersendingConfig
+import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
+import no.nav.familie.ef.mottak.util.lagMeldingPåminnelseManglerDokumentasjonsbehov
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/send-sms-test"])
+@ProtectedWithClaims(issuer = "azuread")
+class TestSmsController(private val producer: DittNavKafkaProducer, private val ettersendingConfig: EttersendingConfig) {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @PostMapping("{passord}")
+    fun sendSmsTilPrivatPerson(@PathVariable passord: String) {
+        val linkMelding = lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
+
+        if (passord.startsWith("240196")) {
+            producer.sendToKafka(
+                passord,
+                linkMelding.melding,
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                linkMelding.link,
+                PreferertKanal.SMS
+            )
+            logger.info("Sendte sms til privatperson")
+        } else {
+            logger.info("Sendte ikke sms til privatperson")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.mottak.task
 
+import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
@@ -54,6 +55,7 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
             task.payload,
             task.metadata["eventId"].toString(),
             linkMelding.link,
+            PreferertKanal.SMS
         )
         logger.info("Sender påminnelse til ditt nav om å sende inn ettersending søknadId=${task.payload}")
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -29,7 +29,6 @@ class SendSøknadMottattTilDittNavTask(
             lagLinkMelding(søknad.dokumenttype),
             task.payload,
             task.metadata["eventId"].toString(),
-            null,
         )
         logger.info("Send melding til ditt nav søknadId=${task.payload}")
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -4,6 +4,7 @@ import io.mockk.called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.featuretoggle.FeatureToggleService
@@ -69,7 +70,7 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadService.get(any())
             søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link)
+            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
         }
     }
 
@@ -128,7 +129,7 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadService.get(any())
             søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link)
+            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
 
         }
     }
@@ -151,7 +152,7 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadService.get(any())
             søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link)
+            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
         }
     }
 


### PR DESCRIPTION
…nsbehov etter to dager

Vi har behov for å sende en "standard sms" til søker dersom hen ikke har sendt inn manglende dokumentasjonsbehov tidligst to dager etter innsendt søknad. 

Dette kan testes i preprod ved å følge siste avsnitt på denne siden: https://navikt.github.io/brukernotifikasjon-docs/eksternvarsling/ Siden dette er litt mekk tar jeg sikte på å få testet førstkommende mandag 

Eventuelt kan det testes i prod ved å sende inn en søknad.