### PR TITLE
Skal håndtere timeouts mot joark ved arkivering av en søknad plikt so…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalfoeringHendelseDbUtil.kt
@@ -14,6 +14,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class JournalfoeringHendelseDbUtil(
@@ -56,7 +57,7 @@ class JournalfoeringHendelseDbUtil(
             type = eksternJournalføringFlyt().first().type,
             payload = journalpost.journalpostId,
             properties = journalpost.metadata(),
-        )
+        ).medTriggerTid(LocalDateTime.now().plusMinutes(15))
         taskService.save(journalføringsTask)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/ArkiverSøknadTask.kt
@@ -21,7 +21,7 @@ class ArkiverSøknadTask(
 
     override fun doTask(task: Task) {
         logger.info("Starter prosessering av task=${task.id}")
-        val journalpostId = arkiveringService.journalførSøknad(task.payload)
+        val journalpostId = arkiveringService.journalførSøknad(task.payload, task.callId)
         logger.info("Oppdaterer metadata til task=${task.id}")
         task.metadata.apply {
             this["journalpostId"] = journalpostId

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/ArkiveringServiceTest.kt
@@ -1,14 +1,18 @@
 package no.nav.familie.ef.mottak.service
 
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_OVERGANGSSTØNAD
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.repository.EttersendingVedleggRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
+import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -50,6 +54,16 @@ internal class ArkiveringServiceTest {
         ettersendingPdf = EncryptedFile("pdf".toByteArray()),
     )
 
+    private val søknad = Søknad(
+        id = UUID.randomUUID().toString(),
+        søknadJson = EncryptedString(data = ""),
+        dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
+        fnr = "",
+        taskOpprettet = false,
+        opprettetTid = LocalDateTime.now(),
+        søknadPdf = EncryptedFile("pdf".toByteArray()),
+    )
+
     private val conflictException =
         HttpClientErrorException.Conflict.create(null, HttpStatus.CONFLICT, null, null, null, null)
 
@@ -66,12 +80,39 @@ internal class ArkiveringServiceTest {
     }
 
     @Test
+    internal fun `Skal håndtere 409 feil fra integrasjoner ved arkivering av søknad som allerede er journalført med callId`() {
+        val forventetJounalføringsId = "1234"
+        val forventetFeil = lagRessursException(conflictException)
+        val journalposter = listOf(lagJournalpost(forventetJounalføringsId, "callId"))
+        every { søknadService.get(any()) } returns søknad
+        every { søknadService.oppdaterSøknad(any()) } just Runs
+        every { integrasjonerClient.arkiver(any()) } throws forventetFeil
+        every { integrasjonerClient.hentJournalposterForBruker(any()) } returns journalposter
+        every { vedleggRepository.findBySøknadId(any()) } returns emptyList()
+        val journalførSøknad = arkiveringService.journalførSøknad("456", "callId")
+        Assertions.assertThat(journalførSøknad).isEqualTo(forventetJounalføringsId)
+    }
+
+    @Test
     internal fun `Skal ikke prøve å håndtere feil som ikke er av type conflict-409 `() {
         val feil = HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR)
         every { ettersendingService.hentEttersending(any()) } returns ettersending
         every { integrasjonerClient.arkiver(any()) } throws lagRessursException(feil)
         val ressursException =
             assertThrows<RessursException> { arkiveringService.journalførEttersending("456", "callId") }
+        Assertions.assertThat(ressursException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        verify(exactly = 0) { integrasjonerClient.hentJournalposterForBruker(any()) }
+    }
+
+    @Test
+    internal fun `Skal ikke prøve å håndtere feil som ikke er av type conflict-409 for arkivering av søknader`() {
+        val feil = HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR)
+        every { søknadService.get(any()) } returns søknad
+        every { søknadService.oppdaterSøknad(any()) } just Runs
+        every { integrasjonerClient.arkiver(any()) } throws lagRessursException(feil)
+        every { vedleggRepository.findBySøknadId(any()) } returns emptyList()
+        val ressursException =
+            assertThrows<RessursException> { arkiveringService.journalførSøknad("456", "callId") }
         Assertions.assertThat(ressursException.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
         verify(exactly = 0) { integrasjonerClient.hentJournalposterForBruker(any()) }
     }


### PR DESCRIPTION
…m ettersending. Må passe på å ikke starte LagEksternJournalføringsoppgaveTask før vi har rekjørt arkiverSøknadTasken på nytt - ettersom vi da risikerer doble oppgaver for journalføring

Scenario:
- Søknad kommer inn
- Arkiverer søknaden mot joark
- Kallet feiler (timeout)
- Kafkamelding på topic om ny journalpost
- LagEksternJournalføringsoppgaveTask opprettes, men 15 minutter frem i tid
- Rekjører feilet task - finner ut at den allerede er journalført og henter ut journalpostId og går "videre" i prosessen
- Følger "normal" løype og prøver å automatisk journalføre søknaden dersom det er mulig
- LagEksternJournalføringsoppgaveTask kjører etter et kvarter og finner ut at det allerede finnes en søknad med denne journalpostId-en og vil derfor "termineres"