### PR TITLE
Bump kontrakter-versjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <confluent.version>7.3.3</confluent.version>
         <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>3.0_20230425152938_f30156b-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230428084827_0b6a892-JAKARTA</kontrakter.version>
         <token-validation.version>3.0.10</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <confluent.version>7.3.3</confluent.version>
         <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>3.0_20230404163639_edb8619-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230425152938_f30156b-JAKARTA</kontrakter.version>
         <token-validation.version>3.0.10</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
@@ -539,6 +539,11 @@ internal object Testdata {
                             "Til",
                             LocalDate.of(2012, 12, 18),
                         ),
+                        land = Søknadsfelt(
+                            label = "I hvilket land oppholdt du deg?",
+                            verdi = "Spania",
+                            svarId = "ESP"
+                        ),
                         årsakUtenlandsopphold = Søknadsfelt(
                             "Hvorfor bodde du i utlandet?",
                             "Granca, Granca, Granca",

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
@@ -542,7 +542,7 @@ internal object Testdata {
                         land = Søknadsfelt(
                             label = "I hvilket land oppholdt du deg?",
                             verdi = "Spania",
-                            svarId = "ESP"
+                            svarId = "ESP",
                         ),
                         årsakUtenlandsopphold = Søknadsfelt(
                             "Hvorfor bodde du i utlandet?",

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
@@ -525,21 +525,21 @@ internal object Testdata {
 
     private fun medlemskapsdetaljer(): Medlemskapsdetaljer {
         return Medlemskapsdetaljer(
-            Søknadsfelt("Oppholder du deg i Norge?", true),
-            Søknadsfelt("Har du bodd i Norge de siste tre årene?", true),
-            Søknadsfelt(
+            oppholderDuDegINorge = Søknadsfelt("Oppholder du deg i Norge?", true),
+            bosattNorgeSisteÅrene = Søknadsfelt("Har du bodd i Norge de siste tre årene?", true),
+            utenlandsopphold = Søknadsfelt(
                 "Utenlandsopphold",
                 listOf(
                     Utenlandsopphold(
-                        Søknadsfelt(
+                        fradato = Søknadsfelt(
                             "Fra",
                             LocalDate.of(2012, 12, 4),
                         ),
-                        Søknadsfelt(
+                        tildato = Søknadsfelt(
                             "Til",
                             LocalDate.of(2012, 12, 18),
                         ),
-                        Søknadsfelt(
+                        årsakUtenlandsopphold = Søknadsfelt(
                             "Hvorfor bodde du i utlandet?",
                             "Granca, Granca, Granca",
                         ),

--- a/src/test/resources/json/pdf_generated_barnetilsyn.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn.json
@@ -153,6 +153,10 @@
               "verdi": "18.12.2012"
             },
             {
+              "label" : "I hvilket land oppholdt du deg?",
+              "verdi" : "Spania"
+            },
+            {
               "label": "Hvorfor bodde du i utlandet?",
               "verdi": "Granca, Granca, Granca"
             }

--- a/src/test/resources/json/pdf_generated_overgangsstønad.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad.json
@@ -153,6 +153,10 @@
               "verdi": "18.12.2012"
             },
             {
+              "label" : "I hvilket land oppholdt du deg?",
+              "verdi" : "Spania"
+            },
+            {
               "label": "Hvorfor bodde du i utlandet?",
               "verdi": "Granca, Granca, Granca"
             }

--- a/src/test/resources/json/pdf_generated_skolepenger.json
+++ b/src/test/resources/json/pdf_generated_skolepenger.json
@@ -131,6 +131,10 @@
               "verdi": "18.12.2012"
             },
             {
+              "label" : "I hvilket land oppholdt du deg?",
+              "verdi" : "Spania"
+            },
+            {
               "label": "Hvorfor bodde du i utlandet?",
               "verdi": "Granca, Granca, Granca"
             }


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12261)
Trenger å bumpe versjonen av kontrakter slik at den tar inn de nye feltene `oppholdsland` i medlemskap og `land` i utenlandsopphold. 

### Andre relevante PR-er: 

- ef-soknad [PR 1245](https://github.com/navikt/familie-ef-soknad/pull/1245) (Lagt til de nye feltene)
- ef-soknad-api [PR 844](https://github.com/navikt/familie-ef-soknad-api/pull/844) (mapper de nye feltene)
- ef-sak PR (legger til de nye feltene i søknadsdata)
- familie-kontrakter [PR 744](https://github.com/navikt/familie-kontrakter/pull/774) (legger til oppholdsland i medlemskap og land i utenlandsopphold) og [PR 746](https://github.com/navikt/familie-kontrakter/pull/776) (gi mulighet til å sette de nye feltene i `TestSøknadsBuilder`)