### PR TITLE
skal sjekke mot ef-sak om en søknad har resultert i en påbegynt behan…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20230505152326_9265101-SPRING_BOOT_3</prosessering.version>
         <confluent.version>7.4.0</confluent.version>
         <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>3.0_20230505152139_b374866-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0-SNAPSHOT</kontrakter.version>
         <token-validation.version>3.0.10</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/SaksbehandlingClient.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.mottak.integration
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringRequest
 import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
+import no.nav.familie.kontrakter.ef.søknad.KanSendePåminnelseRequest
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -51,5 +52,19 @@ class SaksbehandlingClient(
         val response =
             postForEntity<Ressurs<AutomatiskJournalføringResponse>>(sendInnUri, automatiskJournalføringRequest)
         return response.getDataOrThrow()
+    }
+
+    fun kanSendePåminnelseTilBruker(kanSendePåminnelseRequest: KanSendePåminnelseRequest): Boolean {
+        val uri = UriComponentsBuilder.fromUri(uri)
+            .pathSegment("api")
+            .pathSegment("ekstern")
+            .pathSegment("behandling")
+            .pathSegment("kan-sende-påminnelse-til-bruker")
+            .encode()
+            .build()
+            .toUri()
+
+        val response = postForEntity<Ressurs<Boolean>>(uri, kanSendePåminnelseRequest)
+        return response.data ?: error("Kall mot ef-sak feilet melding=${response.melding}")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.mottak.task
 
 import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.familie.ef.mottak.config.EttersendingConfig
+import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
@@ -9,10 +10,13 @@ import no.nav.familie.ef.mottak.service.EttersendingService
 import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.task.SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.Companion.TYPE
 import no.nav.familie.ef.mottak.util.LinkMelding
+import no.nav.familie.ef.mottak.util.dokumenttypeTilStønadType
 import no.nav.familie.ef.mottak.util.lagMeldingPåminnelseManglerDokumentasjonsbehov
 import no.nav.familie.ef.mottak.util.tilDittNavTekst
+import no.nav.familie.kontrakter.ef.søknad.KanSendePåminnelseRequest
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -33,6 +37,7 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
     private val søknadService: SøknadService,
     private val ettersendingService: EttersendingService,
     private val ettersendingConfig: EttersendingConfig,
+    private val saksbehandlingClient: SaksbehandlingClient,
 ) : AsyncTaskStep {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -42,8 +47,9 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         val personIdent = PersonIdent(søknad.fnr)
         val søknader = søknadService.hentSøknaderForPerson(personIdent)
         val ettersendinger = ettersendingService.hentEttersendingerForPerson(personIdent)
+        val stønadstype: StønadType? = dokumenttypeTilStønadType(søknad.dokumenttype)
 
-        if (harSendtInnNySøknad(søknad, søknader) || harSendtInnEttersendingIEttertid(søknad, ettersendinger)) {
+        if (skalIkkeSendePåminnelse(søknad, søknader, ettersendinger, stønadstype)) {
             logger.info("Sender ikke påminnelse til ditt nav om å sende inn ettersending søknadId=${task.payload}")
             return
         }
@@ -60,6 +66,17 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         logger.info("Sender påminnelse til ditt nav om å sende inn ettersending søknadId=${task.payload}")
     }
 
+    private fun skalIkkeSendePåminnelse(
+        søknad: Søknad,
+        søknader: List<Søknad>,
+        ettersendinger: List<Ettersending>,
+        stønadType: StønadType?,
+    ) =
+        harSendtInnNySøknad(søknad, søknader) ||
+            harSendtInnEttersendingIEttertid(søknad, ettersendinger) ||
+            stønadType == null ||
+            tilhørendeBehandleSakOppgaveErPåbegynt(søknad, stønadType)
+
     private fun harSendtInnNySøknad(søknad: Søknad, søknader: List<Søknad>): Boolean =
         søknader.filter { it.id != søknad.id }
             .filter { SøknadType.hentSøknadTypeForDokumenttype(it.dokumenttype) != SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER }
@@ -67,6 +84,15 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
 
     private fun harSendtInnEttersendingIEttertid(søknad: Søknad, ettersendinger: List<Ettersending>): Boolean =
         ettersendinger.any { it.opprettetTid > søknad.opprettetTid }
+
+    private fun tilhørendeBehandleSakOppgaveErPåbegynt(søknad: Søknad, stønadType: StønadType) =
+        saksbehandlingClient.kanSendePåminnelseTilBruker(
+            KanSendePåminnelseRequest(
+                personIdent = søknad.fnr,
+                stønadType = stønadType,
+                innsendtSøknadTidspunkt = søknad.opprettetTid,
+            ),
+        )
 
     private fun lagLinkMelding(søknad: Søknad): LinkMelding {
         val søknadType = SøknadType.hentSøknadTypeForDokumenttype(søknad.dokumenttype)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/util/DittNavUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/util/DittNavUtil.kt
@@ -31,6 +31,6 @@ fun tilDittNavTekst(søknadType: SøknadType): String {
         SøknadType.BARNETILSYN -> "stønad til barnetilsyn"
         SøknadType.OVERGANGSSTØNAD -> "overgangsstønad"
         SøknadType.SKOLEPENGER -> "stønad til skolepenger"
-        else -> error("Kan mappe dokumenttype $søknadType til dittnav tekst")
+        else -> error("Kan ikke mappe dokumenttype $søknadType til dittnav tekst")
     }
 }


### PR DESCRIPTION
…dleSak oppgave før man sender ut sms-varsel om manglende dokumentasjonsbehov mot bruker

**Krever en oppdatering av kontraker:**
* https://github.com/navikt/familie-kontrakter/pull/804

**Hva har blitt gjort?**
Har lagt til en sjekk mot ef-sak som sjekker om innsendt søknad har ført til en påbegynt behandle-sak oppgave. Dette gjøres i task for utsendelse av sms-varsel til søker. Sms-varselet skal ikke sendes dersom søknaden har ført til en påbegynt behandle sak oppgpave.

**PR i familie-ef-sak:**
* https://github.com/navikt/familie-ef-sak/pull/2287
