### PR TITLE
Metric for alle søknader som blir sendt inn og skal behandles for å trigge alerts ved inaktivitet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/JournalføringsoppgaveService.kt
@@ -29,8 +29,8 @@ class JournalføringsoppgaveService(
         Metrics.counter("alene.med.barn.journalhendelse.NyJournalpostHendelse")
 
     fun lagEksternJournalføringTask(journalpost: Journalpost) {
+        nyJournalhendelseCounter.increment()
         if (journalpost.skalBehandles()) {
-            nyJournalhendelseCounter.increment()
             opprettTaskDersomDetIkkeAlleredeFinnes(journalpost)
         } else {
             logJournalpost(journalpost)


### PR DESCRIPTION
[Link til panelet i Grafana](https://grafana.nais.io/d/hULCL_-Wz/familie-overvakning?orgId=1&from=1689213029502&to=1689234629502&viewPanel=58) - metricen som er lagt inn der skal erstattes med denne.

Tok spørringen som brukes for å trigge alerts ved errors i panelet, men prøver å gjøre om alert-triggeren til å trigges dersom snittet på counteren er 0 i 48 timer.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12521)