### PR TITLE
Mottak - flere podder

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -20,8 +20,8 @@ spec:
     enabled: true
     path: /internal/prometheus
   replicas:
-    min: 1
-    max: 1
+    min: 2
+    max: 4
   resources:
     limits:
       memory: 2Gi

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -21,7 +21,7 @@ spec:
     path: /internal/prometheus
   replicas:
     min: 1
-    max: 1
+    max: 4
   resources:
     limits:
       memory: 4Gi

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -20,7 +20,7 @@ spec:
     enabled: true
     path: /internal/prometheus
   replicas:
-    min: 1
+    min: 2
     max: 4
   resources:
     limits:

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
             <version>${felles.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>leader</artifactId>
+            <version>${felles.version}</version>
+        </dependency>
+        <dependency>
             <groupId>no.nav.familie.kontrakter</groupId>
             <artifactId>felles</artifactId>
             <version>${kontrakter.version}</version>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
@@ -25,6 +25,7 @@ class EttersendingService(
     private val ettersendingRepository: EttersendingRepository,
     private val ettersendingVedleggRepository: EttersendingVedleggRepository,
     private val dokumentClient: FamilieDokumentClient,
+    private val taskProsesseringService: TaskProsesseringService,
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -70,6 +71,7 @@ class EttersendingService(
     ) {
         val lagretSkjema = ettersendingRepository.insert(ettersendingDb)
         ettersendingVedleggRepository.insertAll(vedlegg)
+        taskProsesseringService.startTaskProsessering(lagretSkjema)
         logger.info("Mottatt ettersending med id ${lagretSkjema.id}")
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/FjernProsessertDataScheduledEventService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/FjernProsessertDataScheduledEventService.kt
@@ -20,16 +20,15 @@ class FjernProsessertDataScheduledEventService(
 
     @Scheduled(cron = "\${DB_RYDDING_CRON_EXPRESSION}")
     fun ryddGamleForekomster() {
-        if (LeaderClient.isLeader() == true) {
-            logger.info("Starter opprydding i database")
-            reduserSøknadsinnholdOgSlettArkiverteEttersendinger()
-        }else {
-            logger.info("Er ikke leder - starter ikke ryddejobb")
+        when (LeaderClient.isLeader()) {
+            true -> reduserSøknadsinnholdOgSlettArkiverteEttersendinger()
+            false -> logger.info("Er ikke leder - starter ikke ryddejobb")
+            null -> logger.error("Klarer ikke finne leder? Starter ikke ryddejobb.")
         }
-
     }
 
     private fun reduserSøknadsinnholdOgSlettArkiverteEttersendinger() {
+        logger.info("Starter opprydding i database")
         val tidspunktFor3MånederSiden = LocalDateTime.now().minusMonths(3)
         val søknaderTilReduksjon = søknadRepository.finnSøknaderKlarTilReduksjon(tidspunktFor3MånederSiden)
         søknaderTilReduksjon.forEach {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/FjernProsessertDataScheduledEventService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/FjernProsessertDataScheduledEventService.kt
@@ -3,53 +3,19 @@ package no.nav.familie.ef.mottak.service
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
 @Service
-class ScheduledEventService(
+class FjernProsessertDataScheduledEventService(
     private val søknadRepository: SøknadRepository,
     private val ettersendingRepository: EttersendingRepository,
-    private val taskProsesseringService: TaskProsesseringService,
     private val ryddeTaskService: RyddeTaskService,
-    @Value("\${prosessering.enabled:true}")
-    private val prosesserongEnabled: Boolean,
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
-
-    @Scheduled(initialDelay = 10000, fixedDelay = 60000)
-    fun opprettTaskForSøknad() {
-        if (!prosesserongEnabled) return
-
-        val soknad = søknadRepository.findFirstByTaskOpprettetIsFalse()
-        try {
-            soknad?.let {
-                taskProsesseringService.startTaskProsessering(it)
-                logger.info("Task opprettet for søknad med id ${it.id}")
-            }
-        } catch (e: DataIntegrityViolationException) {
-            logger.info("ConstraintViolation ved forsøk på å opprette task for søknad med id ${soknad?.id}")
-        }
-    }
-
-    @Scheduled(initialDelay = 10000, fixedDelay = 60000)
-    fun opprettTaskForEttersending() {
-        if (!prosesserongEnabled) return
-
-        val ettersending = ettersendingRepository.findFirstByTaskOpprettetIsFalse()
-        try {
-            ettersending?.let {
-                taskProsesseringService.startTaskProsessering(it)
-                logger.info("Task opprettet for ettersending med id ${it.id}")
-            }
-        } catch (e: DataIntegrityViolationException) {
-            logger.info("ConstraintViolation ved forsøk på å opprette task for ettersending med id ${ettersending?.id}")
-        }
-    }
 
     @Scheduled(cron = "\${DB_RYDDING_CRON_EXPRESSION}")
     fun ryddGamleForekomster() {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
@@ -25,7 +25,7 @@ class OpprettTaskScheduler(
                 opprettManglendeTasksForEttersending()
             }
             false -> logger.info("Er ikke leder - leter ikke etter manglende tasks for søknad ")
-            null -> logger.info("Leader election returnerer null. Leter ikke etter manglende tasks")
+            null -> logger.warn("Leader election returnerer null. Leter ikke etter manglende tasks")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.ef.mottak.service
+
+import no.nav.familie.ef.mottak.repository.EttersendingRepository
+import no.nav.familie.ef.mottak.repository.SøknadRepository
+import no.nav.familie.leader.LeaderClient
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class OpprettTaskScheduler(
+    private val søknadRepository: SøknadRepository,
+    private val ettersendingRepository: EttersendingRepository,
+    private val taskProsesseringService: TaskProsesseringService,
+) {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Scheduled(initialDelay = 10000, fixedDelay = 1000 * 60 * 30)
+    fun opprettTaskForSøknad() {
+        when (LeaderClient.isLeader()) {
+            true -> {
+                opprettManglendeTaskForSøknad()
+                opprettManglendeTasksForEttersending()
+            }
+            false -> logger.info("Er ikke leder - leter ikke etter manglende tasks for søknad ")
+            null -> logger.info("Leader election returnerer null. Leter ikke etter manglende tasks")
+        }
+    }
+
+    private fun opprettManglendeTaskForSøknad() {
+        val soknad = søknadRepository.findFirstByTaskOpprettetIsFalse()
+        try {
+            soknad?.let {
+                taskProsesseringService.startTaskProsessering(it)
+                logger.info("Task opprettet for søknad med id ${it.id}")
+            }
+        } catch (e: DataIntegrityViolationException) {
+            logger.info("ConstraintViolation ved forsøk på å opprette task for søknad med id ${soknad?.id}")
+        }
+    }
+
+    private fun opprettManglendeTasksForEttersending() {
+        val ettersending = ettersendingRepository.findFirstByTaskOpprettetIsFalse()
+        try {
+            ettersending?.let {
+                taskProsesseringService.startTaskProsessering(it)
+                logger.info("Task opprettet for ettersending med id ${it.id}")
+            }
+        } catch (e: DataIntegrityViolationException) {
+            logger.info("ConstraintViolation ved forsøk på å opprette task for ettersending med id ${ettersending?.id}")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/OpprettTaskScheduler.kt
@@ -17,7 +17,7 @@ class OpprettTaskScheduler(
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    @Scheduled(initialDelay = 10000, fixedDelay = 1000 * 60 * 30)
+    @Scheduled(initialDelay = 10000, fixedDelay = 1000 * 60 * 15)
     fun opprettTaskForSøknad() {
         when (LeaderClient.isLeader()) {
             true -> {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -38,7 +38,7 @@ class SøknadService(
     private val vedleggRepository: VedleggRepository,
     private val dokumentClient: FamilieDokumentClient,
     private val dokumentasjonsbehovRepository: DokumentasjonsbehovRepository,
-    private val taskProsesseringService: TaskProsesseringService
+    private val taskProsesseringService: TaskProsesseringService,
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskMetricService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskMetricService.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ef.mottak.service
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ef.mottak.repository.SøknadRepository
 import no.nav.familie.ef.mottak.repository.TaskMetricRepository
+import no.nav.familie.leader.LeaderClient
+import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
@@ -12,8 +14,19 @@ class TaskMetricService(
     private val søknadRepository: SøknadRepository,
 ) {
 
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     @Scheduled(initialDelay = 5_000, fixedDelay = 5 * 60_000)
     fun oppdaterMetrikker() {
+
+        when (LeaderClient.isLeader()) {
+            true -> oppdaterMetrikkerForOpprettingAvTask()
+            false -> logger.info("Er ikke leder - oppdaterer ikke metrikker")
+            null -> logger.error("Klarer ikke finne leder? Metrikker oppdateres ikke.")
+        }
+    }
+
+    private fun oppdaterMetrikkerForOpprettingAvTask() {
         taskMetricRepository.finnFeiledeTasks().forEach {
             Metrics.gauge("tasks_${it.type}_feilet", it.count)
         }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.mottak.task.LagPdfTask
 import no.nav.familie.ef.mottak.task.SendSøknadMottattTilDittNavTask
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.Properties
@@ -20,6 +21,8 @@ class TaskProsesseringService(
     private val søknadRepository: SøknadRepository,
     private val ettersendingRepository: EttersendingRepository,
 ) {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     @Transactional
     fun startTaskProsessering(søknad: Søknad) {
@@ -43,6 +46,7 @@ class TaskProsesseringService(
             ),
         )
         søknadRepository.update(søknad.copy(taskOpprettet = true))
+        logger.info("Task opprettet for søknad med id ${søknad.id}")
     }
 
     @Transactional

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -68,4 +68,4 @@ JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoe
 
 ettersending.ettersendingUrl: https://familie.ekstern.dev.nav.no/familie/alene-med-barn/ettersending
 
-DB_RYDDING_CRON_EXPRESSION: "* */5 * * * *"
+DB_RYDDING_CRON_EXPRESSION: 0 */5 * ? * *

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -68,4 +68,4 @@ JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoe
 
 ettersending.ettersendingUrl: https://familie.ekstern.dev.nav.no/familie/alene-med-barn/ettersending
 
-DB_RYDDING_CRON_EXPRESSION: 0 */5 * ? * *
+DB_RYDDING_CRON_EXPRESSION: 0 0 * * * ?

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -68,4 +68,4 @@ JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoe
 
 ettersending.ettersendingUrl: https://familie.ekstern.dev.nav.no/familie/alene-med-barn/ettersending
 
-DB_RYDDING_CRON_EXPRESSION: 0 0 * * * ?
+DB_RYDDING_CRON_EXPRESSION: "* */5 * * * *"

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
@@ -24,6 +24,7 @@ import java.util.UUID
 
 internal class EttersendingServiceTest {
 
+    private val taskProsesseringService = mockk<TaskProsesseringService>(relaxed = true)
     private val ettersendingRepository = mockk<EttersendingRepository>(relaxed = true)
     private val ettersendingVedleggRepository = mockk<EttersendingVedleggRepository>(relaxed = true)
     private val dokumentClient = mockFamilieDokumentClient()
@@ -32,6 +33,7 @@ internal class EttersendingServiceTest {
         ettersendingRepository = ettersendingRepository,
         ettersendingVedleggRepository = ettersendingVedleggRepository,
         dokumentClient = dokumentClient,
+        taskProsesseringService = taskProsesseringService,
     )
 
     private val dokument1 = "1234".toByteArray()

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.mottak.repository.VedleggRepository
 import no.nav.familie.ef.mottak.repository.domain.Dokumentasjonsbehov
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
 import no.nav.familie.ef.mottak.service.SøknadService
+import no.nav.familie.ef.mottak.service.TaskProsesseringService
 import no.nav.familie.ef.mottak.service.Testdata
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat
@@ -26,8 +27,10 @@ class SøknadServiceTest {
     private val søknadRepository = mockk<SøknadRepository>(relaxed = true)
     private val vedleggRepository = mockk<VedleggRepository>(relaxed = true)
     private val dokumentasjonsbehovRepository = mockk<DokumentasjonsbehovRepository>(relaxed = true)
+    private val taskProsesseringService = mockk<TaskProsesseringService>(relaxed = true)
+
     private val søknadService =
-        SøknadService(søknadRepository, vedleggRepository, mockk(), dokumentasjonsbehovRepository)
+        SøknadService(søknadRepository, vedleggRepository, mockk(), dokumentasjonsbehovRepository, taskProsesseringService)
 
     @Test
     internal fun `hentDokumentasjonsbehovforPerson fungerer for overgangsstønad, barnetilsyn og skolepenger`() {


### PR DESCRIPTION
**Hvorfor:** Vil gjerne kjøre med mer enn en pod i mottak for ikke få nedetid ved f.eks oom feil. 

**Derfor** : Øker min pods replica til 2. 

**Da må vi også:** 
Hvis vi skal kjøre med mer enn en pod uten å få duplikate tasks, eller feil pga samtidige kall mot db må vi: 

* Fjerne @Scheduled for opprettelse av task gitt nye kolonner i søknadstabell. (skjema, søknader og ettersendinger)
* Legge på leader-selection og bruke leader for å rydde i database og oppdatere metrikker. 

Har testet innsending av OS-søknad og vil teste innsending av BT- og SPsøknad samt innsending av arbeidssøkerskjema og ettersendinger før merging til prod. 

