### PR TITLE
Vil opprette callId pr stønadstype på ettersendingstasks

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/ForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/ForvaltningController.kt
@@ -28,10 +28,9 @@ class ForvaltningController(private val ettersendingService: EttersendingService
 
     @PostMapping("/ettersending/nycallid")
     fun settNyCallIdPåTaskForEttersending(@RequestBody taskId: TaskId): ResponseEntity<String> {
-
         val task = taskService.findById(taskId.id)
         require(task.type == ArkiverEttersendingTask.TYPE)
-        require(task.status == Status.FEILET || task.status == Status.MANUELL_OPPFØLGING) {"Kan ikke legge på ny callId på task når status er ${task.status}"}
+        require(task.status == Status.FEILET || task.status == Status.MANUELL_OPPFØLGING) { "Kan ikke legge på ny callId på task når status er ${task.status}" }
         val generateId = IdUtils.generateId()
         task.metadata.apply {
             this["callId"] = generateId
@@ -40,9 +39,7 @@ class ForvaltningController(private val ettersendingService: EttersendingService
         taskService.save(task)
         return ResponseEntity.ok("Endret callId på task til: $generateId")
     }
-
 }
-
 
 data class TaskId(
     val id: Long,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/config/ApplicationConfig.kt
@@ -31,7 +31,7 @@ import java.time.temporal.ChronoUnit
     "no.nav.familie.prosessering",
     "no.nav.familie.sikkerhet",
     "no.nav.familie.ef.mottak",
-    "no.nav.familie.unleash"
+    "no.nav.familie.unleash",
 )
 @ConfigurationPropertiesScan
 @EnableOAuth2Client(cacheEnabled = true)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/EttersendingService.kt
@@ -25,6 +25,7 @@ class EttersendingService(
     private val ettersendingRepository: EttersendingRepository,
     private val ettersendingVedleggRepository: EttersendingVedleggRepository,
     private val dokumentClient: FamilieDokumentClient,
+    private val taskProsesseringService: TaskProsesseringService,
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -68,10 +69,10 @@ class EttersendingService(
         ettersendingDb: Ettersending,
         vedlegg: List<EttersendingVedlegg>,
     ) {
-        val lagretSkjema = ettersendingRepository.insert(ettersendingDb)
+        val lagretEttersending = ettersendingRepository.insert(ettersendingDb)
         ettersendingVedleggRepository.insertAll(vedlegg)
-        // taskProsesseringService.startTaskProsessering(lagretSkjema)
-        logger.info("Mottatt ettersending med id ${lagretSkjema.id}")
+        taskProsesseringService.startTaskProsessering(lagretEttersending)
+        logger.info("Mottatt ettersending med id ${lagretEttersending.id}")
     }
 
     fun hentEttersending(id: String): Ettersending {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/EttersendingServiceTest.kt
@@ -32,6 +32,7 @@ internal class EttersendingServiceTest {
         ettersendingRepository = ettersendingRepository,
         ettersendingVedleggRepository = ettersendingVedleggRepository,
         dokumentClient = dokumentClient,
+        taskProsesseringService = mockk(relaxed = true),
     )
 
     private val dokument1 = "1234".toByteArray()

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/TaskProsesseringServiceTest.kt
@@ -3,13 +3,18 @@ package no.nav.familie.ef.mottak.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.util.søknad
 import no.nav.familie.ef.mottak.repository.EttersendingRepository
 import no.nav.familie.ef.mottak.repository.SøknadRepository
+import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
+import org.jboss.logging.MDC
 import org.junit.jupiter.api.Test
 
 internal class TaskProsesseringServiceTest {
@@ -18,7 +23,36 @@ internal class TaskProsesseringServiceTest {
     private val søknadRepository: SøknadRepository = mockk(relaxed = true)
     private val ettersendingRepository: EttersendingRepository = mockk(relaxed = true)
 
-    private val scheduledEventService = TaskProsesseringService(taskService, søknadRepository, ettersendingRepository)
+    private val taskProsesseringService = TaskProsesseringService(taskService, søknadRepository, ettersendingRepository)
+
+    private val ettersending = Ettersending(
+
+        ettersendingJson = EncryptedString(data = ""),
+        ettersendingPdf = null,
+        stønadType = StønadType.BARNETILSYN.toString(),
+        journalpostId = null,
+        fnr = "",
+        taskOpprettet = false,
+
+    )
+
+    @Test
+    fun `Skal opprette callId pr stønadstype på ettersendingstasks `() {
+        MDC.put(MDCConstants.MDC_CALL_ID, "Heipådeg")
+        val taskSlot = slot<Task>()
+
+        every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+        every { ettersendingRepository.update(any()) } answers { firstArg() }
+
+        val callIdPre = MDC.get(MDCConstants.MDC_CALL_ID) as? String
+
+        taskProsesseringService.startTaskProsessering(ettersending = ettersending)
+
+        assertThat(taskSlot.captured.callId).isEqualTo(callIdPre + "_" + StønadType.BARNETILSYN.toString())
+
+        taskProsesseringService.startTaskProsessering(ettersending = ettersending.copy(stønadType = StønadType.OVERGANGSSTØNAD.toString()))
+        assertThat(taskSlot.captured.callId).isEqualTo(callIdPre + "_" + StønadType.OVERGANGSSTØNAD.toString())
+    }
 
     @Test
     fun `startTaskProsessering oppretter en task for søknad og setter taskOpprettet på søknaden til true`() {
@@ -30,7 +64,7 @@ internal class TaskProsesseringServiceTest {
         every { søknadRepository.update(capture(soknadSlot)) }
             .answers { soknadSlot.captured }
 
-        scheduledEventService.startTaskProsessering(soknad)
+        taskProsesseringService.startTaskProsessering(soknad)
 
         assertThat(taskSlot.captured.payload).isEqualTo(soknad.id)
         assertThat(soknadSlot.captured.taskOpprettet).isTrue


### PR DESCRIPTION
Vi bruker fortsatt @Scheduled for å opprette task ved innsending av ettersending. 

Ønsker å opprette task i mottak ved innsending av ettersending på samme måte som søknader. 

For at dette skal fungere må alle tasks få unik callId. Det opprettes en task pr stønadstype. 

Ønsker å gjenbruke callId vi har + stønadstype i task. 