### PR TITLE
Nytt endepunkt hent søknadbarnetilsyn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
         <kotlin.version>1.9.10</kotlin.version>
         <springdoc.version>2.2.0</springdoc.version>
         <mockk.version>1.13.8</mockk.version>
-        <felles.version>2.20231019114030_ef92457</felles.version>
-        <prosessering.version>2.20231005144526_f184554</prosessering.version>
+        <felles.version>2.20231023162434_fa320ce</felles.version>
+        <prosessering.version>2.20231026103714_2f17845</prosessering.version>
         <confluent.version>7.5.1</confluent.version>
         <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>3.0_20231019125348_8bd6d02</kontrakter.version>
+        <kontrakter.version>3.0_20231026154353_1ccdbb1</kontrakter.version>
         <token-validation.version>3.1.5</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -12,6 +12,7 @@ import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -42,8 +43,9 @@ class SøknadController(val søknadService: SøknadService) {
         return okEllerKastException { søknadService.mottaSkolepenger(søknad) }
     }
 
-    @PostMapping("barnetilsyn/hent")
-    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): SøknadBarnetilsyn {
-        return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent.ident)
+    @GetMapping("barnetilsyn/hent")
+    fun hentBarnetilsynssøknadForPerson(): SøknadBarnetilsyn {
+        val personIdent = EksternBrukerUtils.hentFnrFraToken()
+        return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -44,8 +44,7 @@ class SøknadController(val søknadService: SøknadService) {
     }
 
     @PostMapping("barnetilsyn/hent")
-    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): String {
-        val datoForSamlivsbrudd = søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent.ident)
-        return datoForSamlivsbrudd
+    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): SøknadBarnetilsyn {
+        return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent.ident)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -8,7 +8,6 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import no.nav.familie.kontrakter.felles.PersonIdent
-import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -44,8 +44,8 @@ class SøknadController(val søknadService: SøknadService) {
     }
 
     @PostMapping("barnetilsyn/hent")
-    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): Ressurs<String> {
+    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): String {
         val datoForSamlivsbrudd = søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent.ident)
-        return Ressurs.success(datoForSamlivsbrudd)
+        return datoForSamlivsbrudd
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -7,6 +7,8 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
+import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
@@ -39,5 +41,11 @@ class SøknadController(val søknadService: SøknadService) {
     @PostMapping("skolepenger")
     fun skolepenger(@RequestBody søknad: SøknadMedVedlegg<SøknadSkolepenger>): Kvittering {
         return okEllerKastException { søknadService.mottaSkolepenger(søknad) }
+    }
+
+    @PostMapping("barnetilsyn/hent")
+    fun hentBarnetilsynssøknadForPerson(@RequestBody personIdent: PersonIdent): Ressurs<String> {
+        val datoForSamlivsbrudd = søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent.ident)
+        return Ressurs.success(datoForSamlivsbrudd)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class SøknadController(val søknadService: SøknadService) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     @PostMapping("overgangsstonad")
     fun overgangsstønad(@RequestBody søknad: SøknadMedVedlegg<SøknadOvergangsstønad>): Kvittering {
@@ -46,6 +47,7 @@ class SøknadController(val søknadService: SøknadService) {
     @GetMapping("barnetilsyn/hent")
     fun hentBarnetilsynssøknadForPerson(): SøknadBarnetilsyn {
         val personIdent = EksternBrukerUtils.hentFnrFraToken()
+        secureLogger.info("PersonIdent: $personIdent")
         return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -7,7 +7,6 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
-import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
@@ -45,9 +44,8 @@ class SøknadController(val søknadService: SøknadService) {
     }
 
     @GetMapping("barnetilsyn/hent")
-    fun hentBarnetilsynssøknadForPerson(): SøknadBarnetilsyn {
+    fun hentBarnetilsynssøknadForPerson(): SøknadBarnetilsyn? {
         val personIdent = EksternBrukerUtils.hentFnrFraToken()
-        secureLogger.info("PersonIdent: $personIdent")
         return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
@@ -25,6 +25,13 @@ interface SøknadRepository :
     )
     fun finnSisteSøknadenPerStønadtype(fnr: String): List<Søknad>
 
+    @Query(
+        """
+        SELECT * FROM soknad WHERE fnr=:fnr AND dokumenttype=:stønadstype ORDER BY opprettet_tid DESC LIMIT 1
+        """,
+    )
+    fun finnSisteSøknadForPersonOgStønadstype(fnr: String, stønadstype: String): Søknad
+
     fun countByTaskOpprettetFalseAndOpprettetTidBefore(opprettetTid: LocalDateTime = LocalDateTime.now().minusHours(2)): Long
 
     fun findAllByFnr(personIdent: String): List<Søknad>

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
@@ -30,7 +30,7 @@ interface SøknadRepository :
         SELECT * FROM soknad WHERE fnr=:fnr AND dokumenttype=:stønadstype ORDER BY opprettet_tid DESC LIMIT 1
         """,
     )
-    fun finnSisteSøknadForPersonOgStønadstype(fnr: String, stønadstype: String): Søknad
+    fun finnSisteSøknadForPersonOgStønadstype(fnr: String, stønadstype: String): Søknad?
 
     fun countByTaskOpprettetFalseAndOpprettetTidBefore(opprettetTid: LocalDateTime = LocalDateTime.now().minusHours(2)): Long
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.mottak.service
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.mottak.api.dto.Kvittering
+import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_BARNETILSYN
 import no.nav.familie.ef.mottak.integration.FamilieDokumentClient
 import no.nav.familie.ef.mottak.mapper.SøknadMapper
 import no.nav.familie.ef.mottak.repository.DokumentasjonsbehovRepository
@@ -101,6 +102,13 @@ class SøknadService(
 
     fun hentSøknaderForPerson(personIdent: PersonIdent): List<Søknad> =
         søknadRepository.findAllByFnr(personIdent.ident)
+
+    fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): String {
+        val søknadFraDb = hentSøknadForPersonOgStønadstype(personIdent, DOKUMENTTYPE_BARNETILSYN)
+        val søknadBarnetilsyn = objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
+        return søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato.toString()
+    }
+    fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)
 
     @Transactional
     fun motta(skjemaForArbeidssøker: SkjemaForArbeidssøker): Kvittering {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -103,12 +103,10 @@ class SøknadService(
     fun hentSøknaderForPerson(personIdent: PersonIdent): List<Søknad> =
         søknadRepository.findAllByFnr(personIdent.ident)
 
-    fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): String {
+    fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): SøknadBarnetilsyn {
         val søknadFraDb = hentSøknadForPersonOgStønadstype(personIdent, DOKUMENTTYPE_BARNETILSYN)
         logger.info("Søknad fra db med id: ${søknadFraDb.id}")
-        val søknadBarnetilsyn = objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
-        logger.info("returnerer samlivsbruddsdato: ${søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato}")
-        return søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato?.verdi.toString()
+        return objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
     }
     fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -103,12 +103,16 @@ class SøknadService(
     fun hentSøknaderForPerson(personIdent: PersonIdent): List<Søknad> =
         søknadRepository.findAllByFnr(personIdent.ident)
 
-    fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): SøknadBarnetilsyn {
+    fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): SøknadBarnetilsyn? {
         val søknadFraDb = hentSøknadForPersonOgStønadstype(personIdent, DOKUMENTTYPE_BARNETILSYN)
-        logger.info("Søknad fra db med id: ${søknadFraDb.id}")
-        return objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
+        logger.info("Søknad fra db med id: ${søknadFraDb?.id}")
+        if (søknadFraDb?.søknadJson?.data != null) {
+            return objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb?.søknadJson?.data)
+        } else {
+            return null
+        }
     }
-    fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)
+    fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad? = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)
 
     @Transactional
     fun motta(skjemaForArbeidssøker: SkjemaForArbeidssøker): Kvittering {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -108,7 +108,7 @@ class SøknadService(
         logger.info("Søknad fra db med id: ${søknadFraDb.id}")
         val søknadBarnetilsyn = objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
         logger.info("returnerer samlivsbruddsdato: ${søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato}")
-        return søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato.toString()
+        return søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato?.verdi.toString()
     }
     fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -105,7 +105,9 @@ class SøknadService(
 
     fun hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent: String): String {
         val søknadFraDb = hentSøknadForPersonOgStønadstype(personIdent, DOKUMENTTYPE_BARNETILSYN)
+        logger.info("Søknad fra db med id: ${søknadFraDb.id}")
         val søknadBarnetilsyn = objectMapper.readValue<SøknadBarnetilsyn>(søknadFraDb.søknadJson.data)
+        logger.info("returnerer samlivsbruddsdato: ${søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato}")
         return søknadBarnetilsyn.sivilstandsdetaljer.verdi.samlivsbruddsdato.toString()
     }
     fun hentSøknadForPersonOgStønadstype(personIdent: String, stønadstype: String): Søknad = søknadRepository.finnSisteSøknadForPersonOgStønadstype(personIdent, stønadstype)


### PR DESCRIPTION
Nytt endepunkt for å hente ut søknadsdata til gjenbruk i barnetilsynsøknad. 
Endepunktet skal brukes av søknad-api: https://github.com/navikt/familie-ef-soknad-api/pull/918

[PR søknad frontend](https://github.com/navikt/familie-ef-soknad/pull/1533)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd)