### PR TITLE
Fiks testfeil som har oppstått pga. nytt år (2023->2024)

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
@@ -88,7 +88,7 @@ internal class AutomatiskJournalføringServiceTest {
         @Test
         internal fun `skal sette høy prioritet når søknad har aktivitet under utdanning i sommerperiode`() {
             val automatiskJournalføringRequestSlot = slot<AutomatiskJournalføringRequest>()
-            val sommertid = LocalDate.of(2023, 7, 20)
+            val sommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
             val soknad = SøknadMapper.fromDto(
                 Testdata.søknadOvergangsstønad.copy(
                     aktivitet = Søknadsfelt(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/AutomatiskJournalføringServiceTest.kt
@@ -118,7 +118,7 @@ internal class AutomatiskJournalføringServiceTest {
         @Test
         internal fun `skal ikke sette høy prioritet når søknad har aktivitet utenfor sommerperiode`() {
             val automatiskJournalføringRequestSlot = slot<AutomatiskJournalføringRequest>()
-            val sommertid = LocalDate.of(2023, 2, 20)
+            val sommertid = LocalDate.of(LocalDateTime.now().year, 2, 20)
             val soknad = SøknadMapper.fromDto(
                 Testdata.søknadOvergangsstønad.copy(
                     aktivitet = Søknadsfelt(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -314,7 +314,7 @@ internal class OppgaveServiceTest {
         fun `ikke sett høy prioritet utenfor sommertid`() {
             val opprettOppgaveSlot = slot<OpprettOppgaveRequest>()
             val soknadId = "123"
-            val utenforSommertid = LocalDate.of(2023, 5, 20)
+            val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 5, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
             every { søknadService.get(soknadId) } returns SøknadMapper.fromDto(
@@ -338,7 +338,7 @@ internal class OppgaveServiceTest {
         fun `ikke sett høy prioritet i sommertid hvis aktivitet ikke er under utdanning`() {
             val opprettOppgaveSlot = slot<OpprettOppgaveRequest>()
             val soknadId = "123"
-            val utenforSommertid = LocalDate.of(2023, 7, 20)
+            val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
             every { søknadService.get(soknadId) } returns SøknadMapper.fromDto(
@@ -362,7 +362,7 @@ internal class OppgaveServiceTest {
         fun `ikke sett høy prioritet i sommertid hvis søknad ikke er overgangsstønad`() {
             val opprettOppgaveSlot = slot<OpprettOppgaveRequest>()
             val soknadId = "123"
-            val utenforSommertid = LocalDate.of(2023, 7, 20)
+            val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
             every { søknadService.get(soknadId) } returns SøknadMapper.fromDto(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -290,7 +290,7 @@ internal class OppgaveServiceTest {
         fun `sett høy prioritet pga sommertid`() {
             val soknadId = "123"
             val opprettOppgaveSlot = slot<OpprettOppgaveRequest>()
-            val sommertid = LocalDate.of(2023, 7, 20)
+            val sommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
             every { søknadService.get(soknadId) } returns SøknadMapper.fromDto(


### PR DESCRIPTION
Tester feiler nå som vi har kommet fram til 2024. Testen bruker ellers "nå", så bytter til "nå" også for år.  