### PR TITLE
Spring321

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: Build, push and deploy to dev-fss
+    name: Build, push and deploy to dev
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.2.1</version>
     </parent>
 
     <properties>
@@ -19,14 +19,14 @@
         <revision>1.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
-        <kotlin.version>1.9.21</kotlin.version>
+        <kotlin.version>1.9.22</kotlin.version>
         <springdoc.version>2.3.0</springdoc.version>
-        <mockk.version>1.13.8</mockk.version>
-        <felles.version>2.20231201131108_ea25dd3</felles.version>
+        <mockk.version>1.13.9</mockk.version>
+        <felles.version>2.20240112101059_13c2d3f</felles.version>
         <prosessering.version>2.20240110093731_0eda75e</prosessering.version>
-        <confluent.version>7.5.2</confluent.version>
-        <brukernotifikasjon-skjemas.version>2.5.2</brukernotifikasjon-skjemas.version>
-        <kontrakter.version>3.0_20231206111937_3c866af</kontrakter.version>
+        <confluent.version>7.5.3</confluent.version>
+        <brukernotifikasjon-skjemas.version>3.0.0</brukernotifikasjon-skjemas.version>
+        <kontrakter.version>3.0_20240109111848_d97569f</kontrakter.version>
         <token-validation.version>3.1.5</token-validation.version>
         <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
         <okhttp3.version>4.9.1</okhttp3.version>
@@ -233,7 +233,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.19.2</version>
+            <version>1.19.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,9 @@
         <felles.version>2.20240112101059_13c2d3f</felles.version>
         <prosessering.version>2.20240110093731_0eda75e</prosessering.version>
         <confluent.version>7.5.3</confluent.version>
-        <brukernotifikasjon-skjemas.version>3.0.0</brukernotifikasjon-skjemas.version>
+        <brukernotifikasjon-skjemas.version>2.6.0</brukernotifikasjon-skjemas.version>
         <kontrakter.version>3.0_20240109111848_d97569f</kontrakter.version>
-        <token-validation.version>3.1.5</token-validation.version>
-        <!-- okhttp3 overskriver spring sin versjon, blir brukt av mock-oauth2-server -->
-        <okhttp3.version>4.9.1</okhttp3.version>
+        <token-validation.version>3.2.0</token-validation.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
         <start-class>no.nav.familie.ef.mottak.ApplicationKt</start-class>
 


### PR DESCRIPTION
Dette er en versjon av: 
https://github.com/navikt/familie-ef-mottak/pull/1093

**Endringer (i forhold til dependabot pr over)** 

Tatt bort okthttp for å få tester til å kjøre
og endret <brukernotifikasjon-skjemas.version> til  2.6.0. 3.0.0 fungerte ikke. 

Tester i preprod (sender en notifikasjon før jeg merger) 
