### PR TITLE
Vil legge til statusendepunkt for at statusplattform skal kunne hente…

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -51,6 +51,8 @@ spec:
         - application: familie-prosessering
           namespace: teamfamilie
           cluster: dev-gcp
+        - application: statuspoll
+          namespace: navdig
     outbound:
       rules:
         - application: familie-ef-maler

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -51,6 +51,8 @@ spec:
         - application: familie-prosessering
           namespace: teamfamilie
           cluster: prod-gcp
+        - application: statuspoll
+          namespace: navdig
     outbound:
       rules:
         - application: familie-ef-maler

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/PingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/PingController.kt
@@ -15,18 +15,4 @@ class PingController {
     fun ping(): String {
         return "Ack - vi har kontakt"
     }
-
-    @GetMapping("/status")
-    @Unprotected
-    fun status(): StatusDto {
-        return StatusDto(status = Plattformstatus.OK, description = "Alt er bra", logLink = null)
-    }
-
-}
-
-const val LOG_URL = "https://logs.adeo.no/app/discover#/view/a3e93b80-c1a5-11ee-a029-75a0ed43c092?_g=()"
-data class StatusDto(val status: Plattformstatus, val description: String? = null, val logLink: String? = LOG_URL)
-
-enum class Plattformstatus {
-    OK, ISSUE, DOWN
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/PingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/PingController.kt
@@ -15,4 +15,18 @@ class PingController {
     fun ping(): String {
         return "Ack - vi har kontakt"
     }
+
+    @GetMapping("/status")
+    @Unprotected
+    fun status(): StatusDto {
+        return StatusDto(status = Plattformstatus.OK, description = "Alt er bra", logLink = null)
+    }
+
+}
+
+const val LOG_URL = "https://logs.adeo.no/app/discover#/view/a3e93b80-c1a5-11ee-a029-75a0ed43c092?_g=()"
+data class StatusDto(val status: Plattformstatus, val description: String? = null, val logLink: String? = LOG_URL)
+
+enum class Plattformstatus {
+    OK, ISSUE, DOWN
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/StatusController.kt
@@ -1,0 +1,70 @@
+package no.nav.familie.ef.mottak.api
+
+import no.nav.familie.ef.mottak.repository.SøknadRepository
+import no.nav.security.token.support.core.api.Unprotected
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping(path = ["/api/status"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class StatusController(val søknadRepository: SøknadRepository) {
+
+    @GetMapping()
+    @Unprotected
+    fun status(): StatusDto {
+        val søknad = søknadRepository.finnSisteLagredeSøknad()
+        val tidSidenSisteLagredeSøknad = Duration.between(LocalDateTime.now(), søknad.opprettetTid)
+
+        when {
+            erNatt() -> {
+                return StatusDto(status = Plattformstatus.OK, description = "Alt er bra", logLink = null)
+            }
+
+            tidSidenSisteLagredeSøknad.toHours() > 24 -> {
+                return StatusDto(
+                    status = Plattformstatus.DOWN,
+                    description = "Det er over 24 timer siden vi mottok en søknad",
+                )
+            }
+
+            tidSidenSisteLagredeSøknad.toHours() > 5 -> {
+                return StatusDto(
+                    status = Plattformstatus.ISSUE,
+                    description = "Det er over 5 timer siden vi mottok en søknad",
+                )
+            }
+
+            tidSidenSisteLagredeSøknad.toHours() > 1 -> {
+                return StatusDto(
+                    status = Plattformstatus.ISSUE,
+                    description = "Det er over 1 time siden vi mottok en søknad",
+                )
+            }
+
+            tidSidenSisteLagredeSøknad.toMinutes() > 20 -> {
+                return StatusDto(
+                    status = Plattformstatus.ISSUE,
+                    description = "Det er over 20 minutter siden siste søknad ble mottatt",
+                )
+            }
+
+            else -> {
+                return StatusDto(status = Plattformstatus.OK, description = "Alt er bra", logLink = null)
+            }
+        }
+    }
+}
+
+const val LOG_URL = "https://logs.adeo.no/app/discover#/view/a3e93b80-c1a5-11ee-a029-75a0ed43c092?_g=()"
+
+data class StatusDto(val status: Plattformstatus, val description: String? = null, val logLink: String? = LOG_URL)
+
+enum class Plattformstatus {
+    OK, ISSUE, DOWN
+}
+
+fun erNatt() = LocalDateTime.now().hour !in 8..21

--- a/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/repository/SøknadRepository.kt
@@ -27,6 +27,13 @@ interface SøknadRepository :
 
     @Query(
         """
+        SELECT * FROM soknad ORDER BY opprettet_tid DESC LIMIT 1
+        """,
+    )
+    fun finnSisteLagredeSøknad(): Søknad
+
+    @Query(
+        """
         SELECT * FROM soknad WHERE fnr=:fnr AND dokumenttype=:stønadstype ORDER BY opprettet_tid DESC LIMIT 1
         """,
     )


### PR DESCRIPTION
Versjon 0.1 av plattform-status. 

Vil legge til statusendepunkt for at statusplattform skal kunne hente info om mottak.
https://status.nav.no/sp/


Dette for å kunne få på plass integrasjon med en "Ping-aktig" statussjekk. 

Testet i preprod. Fungerer greit. 

Vil utvide denne med status gul dersom få mottatte søknader på dagtid på **minutter, eller kanskje rød dersom ingen søknader på **-timer?  

Kanskje legge på cache? 
 