### PR TITLE
Vil ikke logge warning/error når det er helg.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/StatusController.kt
@@ -27,14 +27,15 @@ class StatusController(val søknadRepository: SøknadRepository) {
     }
 
     private fun loggLiteAktivitet(tidSidenSisteLagredeSøknad: Duration) {
-        if (erDagtid()) {
+        if (erDagtid() && !erHelg()) {
             when {
-                tidSidenSisteLagredeSøknad.toHours() > 3 -> logger.error("Status ef-mottak: Det er over 3 timer siden vi mottok en søknad")
-                tidSidenSisteLagredeSøknad.toMinutes() > 15 -> logger.warn("Status ef-mottak: Det er over 15 minutter siden vi mottok en søknad")
-                else -> logger.info("Status ef-mottak: Vi mottok søknad for ${tidSidenSisteLagredeSøknad.toMinutes()} minutter siden")
+                tidSidenSisteLagredeSøknad.toHours() > 3 -> logger.error("Status ef-mottak: Det er ${tidSidenSisteLagredeSøknad.toHours()} timer siden vi mottok en søknad")
+                tidSidenSisteLagredeSøknad.toMinutes() > 20 -> logger.warn("Status ef-mottak: Det er ${tidSidenSisteLagredeSøknad.toMinutes()} siden vi mottok en søknad")
             }
         }
     }
+
+    private fun erHelg() = LocalDateTime.now().dayOfWeek.value in 6..7
 
     private fun statusDto(tidSidenSisteLagredeSøknad: Duration) = when {
         erTidspunktMedForventetAktivitet() -> dagStatus(tidSidenSisteLagredeSøknad)


### PR DESCRIPTION
Vi fikk litt mange error/warnings/info i loggen denne helga. 

Vil ikke logge warning/error når det er helg.
Fjerner info logg
Øker warning fra 15 til 20 min uten søknad.

Dersom det går 12 timer uten søknad vil vi uansett flagge rødt til status. 