### PR TITLE
Skal kunne bruke personident ved opprettelse av oppgaver for å unngå …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/IntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/IntegrasjonerClient.kt
@@ -19,7 +19,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
-import no.nav.familie.kontrakter.felles.personopplysning.Ident
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
@@ -212,11 +211,6 @@ class IntegrasjonerClient(
     fun hentSaksnummer(journalPostId: String): String {
         val response = getForEntity<Ressurs<Map<*, *>>>(lagHentSaksnummerUri(journalPostId))
         return response.getDataOrThrow()["saksnummer"].toString()
-    }
-
-    fun hentAktørId(personident: String): String {
-        val response = postForEntity<Ressurs<MutableMap<*, *>>>(aktørUri, Ident(personident))
-        return response.getDataOrThrow()["aktørId"].toString()
     }
 
     fun hentIdentForAktørId(aktørId: String): String {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.mottak.mapper
 
-import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
@@ -17,9 +16,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Component
-class OpprettOppgaveMapper(
-    private val integrasjonerClient: IntegrasjonerClient,
-) {
+class OpprettOppgaveMapper {
     val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     fun toJournalføringsoppgave(
@@ -58,9 +55,7 @@ class OpprettOppgaveMapper(
         }
 
         return when (journalpost.bruker!!.type) {
-            BrukerIdType.FNR -> {
-                OppgaveIdentV2(ident = integrasjonerClient.hentAktørId(journalpost.bruker!!.id), gruppe = IdentGruppe.AKTOERID)
-            }
+            BrukerIdType.FNR -> OppgaveIdentV2(ident = journalpost.bruker!!.id, gruppe = IdentGruppe.FOLKEREGISTERIDENT)
             BrukerIdType.ORGNR -> OppgaveIdentV2(ident = journalpost.bruker!!.id, gruppe = IdentGruppe.ORGNR)
             BrukerIdType.AKTOERID -> OppgaveIdentV2(ident = journalpost.bruker!!.id, gruppe = IdentGruppe.AKTOERID)
         }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mapper/OpprettOppgaveMapperTest.kt
@@ -1,13 +1,12 @@
 package no.nav.familie.ef.mottak.mapper
 
-import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 internal class OpprettOppgaveMapperTest {
-    private val mapper = OpprettOppgaveMapper(mockk())
+    private val mapper = OpprettOppgaveMapper()
 
     @Test
     internal fun `skal sette frist til 1 dag for journalføringsoppgave opprettet før kl 12`() {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/mockapi/MockConfiguration.kt
@@ -42,7 +42,5 @@ class MockConfiguration {
             override fun lagOppgave(opprettOppgaveRequest: OpprettOppgaveRequest): OppgaveResponse = OppgaveResponse(1)
 
             override fun hentSaksnummer(journalPostId: String): String = "sak1"
-
-            override fun hentAktørId(personident: String): String = "aktørId"
         }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -64,7 +64,7 @@ import kotlin.test.assertEquals
 internal class OppgaveServiceTest {
     private val integrasjonerClient: IntegrasjonerClient = mockk()
     private val søknadService: SøknadService = mockk()
-    private val opprettOppgaveMapper = spyk(OpprettOppgaveMapper(integrasjonerClient))
+    private val opprettOppgaveMapper = spyk(OpprettOppgaveMapper())
     private val ettersendingService = mockk<EttersendingService>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val cacheManager = ConcurrentMapCacheManager()
@@ -80,7 +80,6 @@ internal class OppgaveServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { integrasjonerClient.hentAktørId(any()) } returns Testdata.randomAktørId()
         every { integrasjonerClient.hentIdentForAktørId(any()) } returns Testdata.randomFnr()
         every { integrasjonerClient.finnBehandlendeEnhetForPersonMedRelasjoner(any()) } returns
             listOf(


### PR DESCRIPTION
…unødvendige kall for aktørid

Siden vi kan opprette oppgaver med personident i stedet for aktørID, så gjør vi det sånn at vi slipper å hente aktørID fra familie-integrasjoner. 

Basert på favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20981