### PR TITLE
Oppdaterer kafka config

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/config/KafkaConfig.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ef.mottak.config
 
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import no.nav.familie.kafka.KafkaErrorHandler
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.boot.ssl.SslBundles
@@ -29,6 +31,8 @@ class KafkaConfig {
         consumerProperties[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
         consumerProperties[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
         consumerProperties[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
+        consumerProperties[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        consumerProperties[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java
 
         val factory = ConcurrentKafkaListenerContainerFactory<Long, JournalfoeringHendelseRecord>()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE

--- a/src/main/kotlin/no/nav/familie/ef/mottak/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/config/KafkaConfig.kt
@@ -1,8 +1,12 @@
 package no.nav.familie.ef.mottak.config
 
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import no.nav.familie.kafka.KafkaErrorHandler
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.boot.ssl.SslBundles
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
@@ -18,12 +22,18 @@ class KafkaConfig {
     fun kafkaJournalføringHendelseListenerContainerFactory(
         properties: KafkaProperties,
         kafkaErrorHandler: KafkaErrorHandler,
+        sslBundles: ObjectProvider<SslBundles>,
     ): ConcurrentKafkaListenerContainerFactory<Long, JournalfoeringHendelseRecord> {
-        properties.properties["specific.avro.reader"] = "true"
+        val consumerProperties = properties.buildConsumerProperties(sslBundles.getIfAvailable())
+        consumerProperties[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 1
+        consumerProperties[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        consumerProperties[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+        consumerProperties[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
+
         val factory = ConcurrentKafkaListenerContainerFactory<Long, JournalfoeringHendelseRecord>()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
         factory.containerProperties.authExceptionRetryInterval = Duration.ofSeconds(2)
-        factory.consumerFactory = DefaultKafkaConsumerFactory(properties.buildConsumerProperties())
+        factory.consumerFactory = DefaultKafkaConsumerFactory(consumerProperties)
         factory.setCommonErrorHandler(kafkaErrorHandler)
         return factory
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,13 +29,6 @@ spring:
           type: PKCS12
           location: ${KAFKA_TRUSTSTORE_PATH}
           password: ${KAFKA_CREDSTORE_PASSWORD}
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      group-id: srvfamilie-ef-mot
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
     producer:
       acks: all
       key-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -16,13 +16,6 @@ spring:
       schema.registry.url: http://localhost:8081
       security:
         protocol: PLAINTEXT
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      group-id: srvc01
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
 
 familie:
   ef:

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -18,13 +18,6 @@ spring:
       schema.registry.url: http://localhost:8081
       security:
         protocol: PLAINTEXT
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-      group-id: srvc01
-      max-poll-records: 1
-      auto-offset-reset: latest
-      enable-auto-commit: false
 
 familie:
   ef:


### PR DESCRIPTION
Fix deprecated metode.

Forsøker å forbedre lesbarhet ved å legge all kafka-config for listeners på ett sted, hvis dere er enige at denne måten er bedre? Tenker det kan være greit å ha dette som felles måte og skrive kafka config for listeners på, for i andre apper som har flere listeners må man uansett ha en egen kafka-config utover det som er i `application.yml`

Testet at hendelser leses i preprod med denne configen.