### PR TITLE
Legg til adresse formatering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfKvitteringClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfKvitteringClient.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ef.mottak.integration
 import no.nav.familie.ef.mottak.repository.domain.FeltMap
 import no.nav.familie.ef.mottak.util.medContentTypeJsonUTF8
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.kontrakter.felles.objectMapper
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -18,6 +20,7 @@ class PdfKvitteringClient(
     @Qualifier("restTemplateAzure")
     restOperations: RestOperations,
 ) : AbstractPingableRestClient(restOperations, "familie-pdf") {
+    private val logger = LoggerFactory.getLogger(this::class.java)
     override val pingUri: URI =
         UriComponentsBuilder
             .fromUri(uri)
@@ -32,6 +35,8 @@ class PdfKvitteringClient(
                 .pathSegment("api/v1/pdf/opprett-pdf")
                 .build()
                 .toUri()
+        logger.info("Sender med body: ${objectMapper.writeValueAsString(feltMap)}")
+        println(" Sender med body: ${objectMapper.writeValueAsString(feltMap)}")
         return postForEntity(uri, feltMap, HttpHeaders().medContentTypeJsonUTF8())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfKvitteringClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/integration/PdfKvitteringClient.kt
@@ -20,7 +20,6 @@ class PdfKvitteringClient(
     @Qualifier("restTemplateAzure")
     restOperations: RestOperations,
 ) : AbstractPingableRestClient(restOperations, "familie-pdf") {
-    private val logger = LoggerFactory.getLogger(this::class.java)
     override val pingUri: URI =
         UriComponentsBuilder
             .fromUri(uri)
@@ -35,8 +34,6 @@ class PdfKvitteringClient(
                 .pathSegment("api/v1/pdf/opprett-pdf")
                 .build()
                 .toUri()
-        logger.info("Sender med body: ${objectMapper.writeValueAsString(feltMap)}")
-        println(" Sender med body: ${objectMapper.writeValueAsString(feltMap)}")
         return postForEntity(uri, feltMap, HttpHeaders().medContentTypeJsonUTF8())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/Feltformaterer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/Feltformaterer.kt
@@ -89,10 +89,19 @@ object Feltformaterer {
 
     private fun tilUtskriftsformat(verdi: LocalDate): String = verdi.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
 
-    private fun tilUtskriftsformat(adresse: Adresse): String =
-        listOf(
-            adresse.adresse,
-            listOf(adresse.postnummer, adresse.poststedsnavn).joinToString(" "),
-            adresse.land,
-        ).joinToString("\n\n")
+    private fun tilUtskriftsformat(adresse: Adresse): String {
+        val adresseelementer = listOfNotNull(
+            adresse.adresse?.takeIf { it.isNotBlank() },
+            listOfNotNull(adresse.postnummer, adresse.poststedsnavn)
+                .joinToString(" ") { it.trim() }
+                .takeIf { it.isNotBlank() },
+            adresse.land?.takeIf { it.isNotBlank() }
+        )
+
+        return if (adresseelementer.isEmpty()) {
+            "Ingen registrert adresse"
+        } else {
+            adresseelementer.joinToString("\n")
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMap.kt
@@ -121,7 +121,7 @@ object SøknadTilFeltMap {
                 return mapDokumentasjon(entitet as Søknadsfelt<Dokumentasjon>)
             }
             if (entitet.verdi!!::class in endNodes) {
-                return Feltformaterer.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
+                return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
             }
             if ((entitet.label == "Barna dine" || entitet.label == "Your children") && entitet.verdi is List<*>) {
                 val elementLabel = if (entitet.label == "Barna dine") "Barn" else "Child"
@@ -152,7 +152,7 @@ object SøknadTilFeltMap {
                 val verdiliste = entitet.verdi as List<*>
 
                 if (verdiliste.firstOrNull() is String) {
-                    return Feltformaterer.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
+                    return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
                 }
             }
             // skal ekskluderes
@@ -166,7 +166,7 @@ object SøknadTilFeltMap {
     }
 
     private fun mapDokumentasjon(entitet: Søknadsfelt<Dokumentasjon>): List<VerdilisteElement> {
-        val list = listOf(Feltformaterer.genereltFormatMapperMapEndenode(entitet.verdi.harSendtInnTidligere))
+        val list = listOf(FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet.verdi.harSendtInnTidligere))
         if (list.size == 1 && list.first()?.verdiliste.isNullOrEmpty() && list.first()?.verdi.isNullOrEmpty()) {
             return emptyList()
         }
@@ -213,7 +213,7 @@ object SøknadTilFeltMap {
         label: String = "Vedlegg",
     ) = VerdilisteElement(
         label,
-        verdiliste = listOf(Feltformaterer.mapVedlegg(vedleggTitler)),
+        verdiliste = listOf(FeltformatererPdfKvittering.mapVedlegg(vedleggTitler)),
         visningsVariant = VisningsVariant.VEDLEGG.toString(),
     )
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvitteringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvitteringTest.kt
@@ -1,6 +1,7 @@
-package no.nav.familie.ef.mottak.service
+package no.nav.familie.ef.mottak.no.nav.familie.ef.mottak.service
 
 import no.nav.familie.ef.mottak.repository.domain.VerdilisteElement
+import no.nav.familie.ef.mottak.service.FeltformatererPdfKvittering
 import no.nav.familie.kontrakter.ef.søknad.Adresse
 import no.nav.familie.kontrakter.ef.søknad.Datoperiode
 import no.nav.familie.kontrakter.ef.søknad.MånedÅrPeriode
@@ -13,12 +14,12 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
 
-internal class FeltformatererTest {
+internal class FeltformatererPdfKvitteringTest {
     @Test
     fun `mapEndenodeTilUtskriftMap formaterer Month korrekt`() {
         val testverdi = Søknadsfelt("label", Month.DECEMBER)
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "desember"))
     }
@@ -27,7 +28,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer Boolean korrekt`() {
         val testverdi = Søknadsfelt("label", true)
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ja"))
     }
@@ -36,7 +37,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer liste med Boolean korrekt`() {
         val testverdi = Søknadsfelt("label", listOf(true, false))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ja\n\nNei"))
     }
@@ -45,7 +46,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer List korrekt`() {
         val testverdi = Søknadsfelt<List<*>>("label", listOf("Lille", "Grimme", "Arne", "Trenger", "Ris"))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Lille\n\nGrimme\n\nArne\n\nTrenger\n\nRis"))
     }
@@ -55,7 +56,7 @@ internal class FeltformatererTest {
         val fnr = FnrGenerator.generer()
         val testverdi = Søknadsfelt("label", Fødselsnummer(fnr))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = fnr))
     }
@@ -64,16 +65,43 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer Adresse korrekt`() {
         val testverdi = Søknadsfelt("label", Adresse("Husebyskogen 15", "1572", "Fet", "Norge"))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
-        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n\n1572 Fet\n\nNorge"))
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n1572 Fet\nNorge"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med tomme felter korrekt`() {
+        val testverdi = Søknadsfelt("label", Adresse("", "", "", ""))
+
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ingen registrert adresse"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med delvis utfylte felter korrekt`() {
+        val testverdi = Søknadsfelt("label", Adresse("Husebyskogen 15", "", "Fet", ""))
+
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n Fet"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med kun land`() {
+        val testverdi = Søknadsfelt("label", Adresse("", "", "", "Norge"))
+
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Norge"))
     }
 
     @Test
     fun `mapEndenodeTilUtskriftMap formaterer LocalDate korrekt`() {
         val testverdi = Søknadsfelt<LocalDate>("label", LocalDate.of(2015, 12, 5))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "05.12.2015"))
     }
@@ -82,7 +110,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer LocalDateTime korrekt`() {
         val testverdi = Søknadsfelt<LocalDateTime>("label", LocalDateTime.of(2015, 12, 5, 14, 52, 48))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "05.12.2015 14:52:48"))
     }
@@ -91,7 +119,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer MånedÅrPeriode korrekt`() {
         val testverdi = Søknadsfelt("label", MånedÅrPeriode(Month.FEBRUARY, 2015, Month.JULY, 2018))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Fra februar 2015 til juli 2018"))
     }
@@ -100,7 +128,7 @@ internal class FeltformatererTest {
     fun `mapEndenodeTilUtskriftMap formaterer Datoperiode korrekt`() {
         val testverdi = Søknadsfelt("label", Datoperiode(LocalDate.of(2015, 2, 1), LocalDate.of(2018, 7, 14)))
 
-        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Fra 01.02.2015 til 14.07.2018"))
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererTest.kt
@@ -66,7 +66,34 @@ internal class FeltformatererTest {
 
         val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
 
-        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n\n1572 Fet\n\nNorge"))
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n1572 Fet\nNorge"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med tomme felter korrekt`() {
+        val testverdi = Søknadsfelt("label", Adresse("", "", "", ""))
+
+        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ingen registrert adresse"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med delvis utfylte felter korrekt`() {
+        val testverdi = Søknadsfelt("label", Adresse("Husebyskogen 15", "", "Fet", ""))
+
+        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n Fet"))
+    }
+
+    @Test
+    fun `mapEndenodeTilUtskriftMap håndterer adresse med kun land`() {
+        val testverdi = Søknadsfelt("label", Adresse("", "", "", "Norge"))
+
+        val resultat = Feltformaterer.mapEndenodeTilUtskriftMap(testverdi)
+
+        assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Norge"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
@@ -158,7 +158,7 @@ class SøknadTilFeltMapTest {
     ) {
         val pdf = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(mapSøknadsfelter)
         // kommentere ut for å skrive over fila
-        // java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
+        java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
         Assertions.assertThat(pdf).isEqualToIgnoringWhitespace(IOTestUtil.readFile(filename))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
@@ -190,7 +190,7 @@ class SøknadTilFeltMapTest {
     ) {
         val pdf = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(mapSøknadsfelter)
         // kommentere ut for å skrive over fila
-        java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
+        // java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
         Assertions.assertThat(pdf).isEqualToIgnoringWhitespace(IOTestUtil.readFile(filename))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
@@ -115,7 +115,7 @@ class SøknadTreeWalkerTest {
     ) {
         val pdf = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(mapSøknadsfelter)
         // kommentere ut for å skrive over fila
-        // java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
+        java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
         assertThat(pdf).isEqualToIgnoringWhitespace(readFile(filename))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTreeWalkerTest.kt
@@ -115,7 +115,7 @@ class SøknadTreeWalkerTest {
     ) {
         val pdf = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(mapSøknadsfelter)
         // kommentere ut for å skrive over fila
-        java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
+        // java.nio.file.Files.write(java.nio.file.Path.of("src/test/resources/json/$filename"), pdf.toByteArray())
         assertThat(pdf).isEqualToIgnoringWhitespace(readFile(filename))
     }
 }

--- a/src/test/resources/json/pdf_generated_barnetilsyn.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn.json
@@ -19,7 +19,7 @@
       "verdi" : "Norsk"
     }, {
       "label" : "Adresse",
-      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+      "verdi" : "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
     }, {
       "label" : "Sivilstand",
       "verdi" : "Ugift"

--- a/src/test/resources/json/pdf_generated_barnetilsyn.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn.json
@@ -1,596 +1,418 @@
 {
-  "label": "Søknad om stønad til barnetilsyn (NAV 15-00.02)",
-  "verdiliste": [
-    {
-      "label": "detaljer",
-      "verdiliste": [
-        {
-          "label": "mottat",
-          "verdi": "01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Søker",
-      "verdiliste": [
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Navn",
-          "verdi": "Kari Nordmann"
-        },
-        {
-          "label": "Statsborgerskap",
-          "verdi": "Norsk"
-        },
-        {
-          "label": "Adresse",
-          "verdi": "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
-        },
-        {
-          "label": "Sivilstand",
-          "verdi": "Ugift"
-        }
-      ]
-    },
-    {
-      "label": "Opplysninger om adresse",
-      "verdiliste": [
-        {
-          "label": "Bor du på denne adressen?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Har du meldt adresseendring til folkeregisteret",
-          "verdi": "Ja"
-        },
-        {
-          "label": "DokumentasjonForAdresseendring",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Detaljer om sivilstand",
-      "verdiliste": [
-        {
-          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "giftIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når søkte dere eller reiste sak?",
-          "verdi": "23.12.2015"
-        },
-        {
-          "label": "Skilsmisse- eller separasjonsbevilling",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Hva er grunnen til at du er alene med barn?",
-          "verdi": "Endring i samværsordning"
-        },
-        {
-          "label": "Erklæring om samlivsbrudd",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dato for samlivsbrudd",
-          "verdi": "03.10.2014"
-        },
-        {
-          "label": "Når flyttet dere fra hverandre?",
-          "verdi": "04.10.2014"
-        },
-        {
-          "label": "Når skjedde endringen / når skal endringen skje?",
-          "verdi": "17.04.2013"
-        }
-      ]
-    },
-    {
-      "label": "Opphold i Norge",
-      "verdiliste": [
-        {
-          "label": "Oppholder du deg i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Har du bodd i Norge de siste tre årene?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Utenlandsopphold",
-          "verdiliste": [
-            {
-              "label": "Fra",
-              "verdi": "04.12.2012"
-            },
-            {
-              "label": "Til",
-              "verdi": "18.12.2012"
-            },
-            {
-              "label" : "I hvilket land oppholdt du deg?",
-              "verdi" : "Spania"
-            },
-            {
-              "label": "Hvorfor bodde du i utlandet?",
-              "verdi": "Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Bosituasjonen din",
-      "verdiliste": [
-        {
-          "label": "Deler du bolig med andre voksne?",
-          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label": "Om samboeren din",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        },
-        {
-          "label": "Når flyttet dere sammen?",
-          "verdi": "12.08.2018"
-        }
-      ]
-    },
-    {
-      "label": "Sivilstandsplaner",
-      "verdiliste": [
-        {
-          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når skal dette skje?",
-          "verdi": "15.04.2021"
-        },
-        {
-          "label": "Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Barn",
-      "verdiliste": [
-        {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
-            },
-            {
-              "label": "Erklæring om samlivsbrudd",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        },
-        {
-          "label": "Skal ha barnepass",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Barnepass",
-          "verdiliste": [
-            {
-              "label": "Årsak Barnepass",
-              "verdi": "Årsak"
-            },
-            {
-              "label": "Ordninger",
-              "verdiliste": [
-                {
-                  "label": "Hva slags barnepassordning?",
-                  "verdi": "En"
-                },
-                {
-                  "label": "Navn",
-                  "verdi": "navn"
-                },
-                {
-                  "label": "Periode",
-                  "verdi": "Fra januar 2020 til juli 2020"
-                },
-                {
-                  "label": "Periode",
-                  "verdi": "Fra 12.01.2020 til 15.02.2020"
-                },
-                {
-                  "label": "Beløp",
-                  "verdi": "1000,21"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Arbeid, utdanning og andre aktiviteter",
-      "verdiliste": [
-        {
-          "label": "Hvordan er arbeidssituasjonen din?",
-          "verdi": "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
-        },
-        {
-          "label": "Om arbeidsforholdet ditt",
-          "verdiliste": [
-            {
-              "label": "Navn på arbeidsgiveren",
-              "verdi": "Palpatine"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "15"
-            },
-            {
-              "label": "Er stillingen fast eller midlertidig?",
-              "verdi": "Fast"
-            },
-            {
-              "label": "Har du en sluttdato?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når skal du slutte?",
-              "verdi": "18.11.2020"
-            }
-          ]
-        },
-        {
-          "label": "Om firmaet du driver",
-          "verdiliste": [
-            {
-              "label": "Navn på firma",
-              "verdi": "Bobs burgers"
-            },
-            {
-              "label": "Organisasjonsnummer",
-              "verdi": "987654321"
-            },
-            {
-              "label": "Når etablerte du firmaet?",
-              "verdi": "05.04.2018"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "150"
-            },
-            {
-              "label": "Hvordan ser arbeidsuken din ut?",
-              "verdi": "Veldig tung"
-            }
-          ]
-        },
-        {
-          "label": "Om virksomheten du etablerer",
-          "verdiliste": [
-            {
-              "label": "Beskriv virksomheten",
-              "verdi": "Den kommer til å revolusjonere verden"
-            }
-          ]
-        },
-        {
-          "label": "Når du er arbeidssøker",
-          "verdiliste": [
-            {
-              "label": "Er du registrert som arbeidssøker hos NAV?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
-              "verdi": "Nei"
-            },
-            {
-              "label": "Hvor ønsker du å søke arbeid?",
-              "verdi": "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
-            },
-            {
-              "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Utdanningen du skal ta",
-          "verdiliste": [
-            {
-              "label": "Skole/utdanningssted",
-              "verdi": "UiO"
-            },
-            {
-              "label": "Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Profesjonsstudium Informatikk"
-                },
-                {
-                  "label": "Når skal du være elev/student?",
-                  "verdi": "Fra 01.01.1999 til 01.10.2004"
-                }
-              ]
-            },
-            {
-              "label": "Er utdanningen offentlig eller privat?",
-              "verdi": "Offentlig"
-            },
-            {
-              "label": "Heltid, eller deltid",
-              "verdi": "Deltid"
-            },
-            {
-              "label": "Hvor mye skal du studere?",
-              "verdi": "300"
-            },
-            {
-              "label": "Hva er målet med utdanningen?",
-              "verdi": "Økonomisk selvstendighet"
-            },
-            {
-              "label": "Har du tatt utdanning etter grunnskolen?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Tidligere Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Master Fysikk"
-                },
-                {
-                  "label": "Når var du elev/student?",
-                  "verdi": "Fra januar 1999 til oktober 2004"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Når søker du stønad fra?",
-      "verdiliste": [
-        {
-          "label": "Søke fra bestemt mnd",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Fra måned",
-          "verdi": "august"
-        },
-        {
-          "label": "Fra år",
-          "verdi": "2018"
-        }
-      ]
-    },
-    {
-      "label": "Barnepassordning faktura",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Avtale barnepasser",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Arbeidstid",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Spesielle behov",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Vedlegg",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
-        }
-      ]
-    }
-  ]
+  "label" : "Søknad om stønad til barnetilsyn (NAV 15-00.02)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Opplysninger om adresse",
+    "verdiliste" : [ {
+      "label" : "Bor du på denne adressen?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Har du meldt adresseendring til folkeregisteret",
+      "verdi" : "Ja"
+    }, {
+      "label" : "DokumentasjonForAdresseendring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barn",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    }, {
+      "label" : "Skal ha barnepass",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Barnepass",
+      "verdiliste" : [ {
+        "label" : "Årsak Barnepass",
+        "verdi" : "Årsak"
+      }, {
+        "label" : "Ordninger",
+        "verdiliste" : [ {
+          "label" : "Hva slags barnepassordning?",
+          "verdi" : "En"
+        }, {
+          "label" : "Navn",
+          "verdi" : "navn"
+        }, {
+          "label" : "Periode",
+          "verdi" : "Fra januar 2020 til juli 2020"
+        }, {
+          "label" : "Periode",
+          "verdi" : "Fra 12.01.2020 til 15.02.2020"
+        }, {
+          "label" : "Beløp",
+          "verdi" : "1000,21"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Hvordan er arbeidssituasjonen din?",
+      "verdi" : "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
+    }, {
+      "label" : "Om arbeidsforholdet ditt",
+      "verdiliste" : [ {
+        "label" : "Navn på arbeidsgiveren",
+        "verdi" : "Palpatine"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "15"
+      }, {
+        "label" : "Er stillingen fast eller midlertidig?",
+        "verdi" : "Fast"
+      }, {
+        "label" : "Har du en sluttdato?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når skal du slutte?",
+        "verdi" : "18.11.2020"
+      } ]
+    }, {
+      "label" : "Om firmaet du driver",
+      "verdiliste" : [ {
+        "label" : "Navn på firma",
+        "verdi" : "Bobs burgers"
+      }, {
+        "label" : "Organisasjonsnummer",
+        "verdi" : "987654321"
+      }, {
+        "label" : "Når etablerte du firmaet?",
+        "verdi" : "05.04.2018"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "150"
+      }, {
+        "label" : "Hvordan ser arbeidsuken din ut?",
+        "verdi" : "Veldig tung"
+      } ]
+    }, {
+      "label" : "Om virksomheten du etablerer",
+      "verdiliste" : [ {
+        "label" : "Beskriv virksomheten",
+        "verdi" : "Den kommer til å revolusjonere verden"
+      } ]
+    }, {
+      "label" : "Når du er arbeidssøker",
+      "verdiliste" : [ {
+        "label" : "Er du registrert som arbeidssøker hos NAV?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
+        "verdi" : "Nei"
+      }, {
+        "label" : "Hvor ønsker du å søke arbeid?",
+        "verdi" : "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
+      }, {
+        "label" : "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      } ]
+    }, {
+      "label" : "Utdanningen du skal ta",
+      "verdiliste" : [ {
+        "label" : "Skole/utdanningssted",
+        "verdi" : "UiO"
+      }, {
+        "label" : "Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Profesjonsstudium Informatikk"
+        }, {
+          "label" : "Når skal du være elev/student?",
+          "verdi" : "Fra 01.01.1999 til 01.10.2004"
+        } ]
+      }, {
+        "label" : "Er utdanningen offentlig eller privat?",
+        "verdi" : "Offentlig"
+      }, {
+        "label" : "Heltid, eller deltid",
+        "verdi" : "Deltid"
+      }, {
+        "label" : "Hvor mye skal du studere?",
+        "verdi" : "300"
+      }, {
+        "label" : "Hva er målet med utdanningen?",
+        "verdi" : "Økonomisk selvstendighet"
+      }, {
+        "label" : "Har du tatt utdanning etter grunnskolen?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Tidligere Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Master Fysikk"
+        }, {
+          "label" : "Når var du elev/student?",
+          "verdi" : "Fra januar 1999 til oktober 2004"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Når søker du stønad fra?",
+    "verdiliste" : [ {
+      "label" : "Søke fra bestemt mnd",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Fra måned",
+      "verdi" : "august"
+    }, {
+      "label" : "Fra år",
+      "verdi" : "2018"
+    } ]
+  }, {
+    "label" : "Barnepassordning faktura",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Avtale barnepasser",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Arbeidstid",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Spesielle behov",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_barnetilsyn_med_typer.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn_med_typer.json
@@ -1,598 +1,420 @@
 {
-  "label": "Søknad om stønad til barnetilsyn (NAV 15-00.02)",
-  "verdiliste": [
-    {
-      "label": "detaljer",
-      "verdiliste": [
-        {
-          "label": "mottat",
-          "verdi": "01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Søker",
-      "verdiliste": [
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Navn",
-          "verdi": "Kari Nordmann"
-        },
-        {
-          "label": "Statsborgerskap",
-          "verdi": "Norsk"
-        },
-        {
-          "label": "Adresse",
-          "verdi": "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
-        },
-        {
-          "label": "Sivilstand",
-          "verdi": "Ugift"
-        }
-      ]
-    },
-    {
-      "label": "Opplysninger om adresse",
-      "verdiliste": [
-        {
-          "label": "Bor du på denne adressen?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Har du meldt adresseendring til folkeregisteret",
-          "verdi": "Ja"
-        },
-        {
-          "label": "DokumentasjonForAdresseendring",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Detaljer om sivilstand",
-      "verdiliste": [
-        {
-          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "giftIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når søkte dere eller reiste sak?",
-          "verdi": "23.12.2015"
-        },
-        {
-          "label": "Skilsmisse- eller separasjonsbevilling",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Hva er grunnen til at du er alene med barn?",
-          "verdi": "Endring i samværsordning"
-        },
-        {
-          "label": "Erklæring om samlivsbrudd",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dato for samlivsbrudd",
-          "verdi": "03.10.2014"
-        },
-        {
-          "label": "Når flyttet dere fra hverandre?",
-          "verdi": "04.10.2014"
-        },
-        {
-          "label": "Når skjedde endringen / når skal endringen skje?",
-          "verdi": "17.04.2013"
-        }
-      ]
-    },
-    {
-      "label": "Opphold i Norge",
-      "verdiliste": [
-        {
-          "label": "Oppholder du deg i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Har du bodd i Norge de siste tre årene?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Utenlandsopphold",
-          "verdiliste": [
-            {
-              "label": "Fra",
-              "verdi": "04.12.2012"
-            },
-            {
-              "label": "Til",
-              "verdi": "18.12.2012"
-            },
-            {
-              "label" : "I hvilket land oppholdt du deg?",
-              "verdi" : "Spania"
-            },
-            {
-              "label": "Hvorfor bodde du i utlandet?",
-              "verdi": "Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Bosituasjonen din",
-      "verdiliste": [
-        {
-          "label": "Deler du bolig med andre voksne?",
-          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label": "Om samboeren din",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        },
-        {
-          "label": "Når flyttet dere sammen?",
-          "verdi": "12.08.2018"
-        }
-      ]
-    },
-    {
-      "label": "Sivilstandsplaner",
-      "verdiliste": [
-        {
-          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når skal dette skje?",
-          "verdi": "15.04.2021"
-        },
-        {
-          "label": "Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Barn",
-      "verdiliste": [
-        {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
-            },
-            {
-              "label": "Erklæring om samlivsbrudd",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        },
-        {
-          "label": "Skal ha barnepass",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Barnepass",
-          "verdiliste": [
-            {
-              "label": "Årsak Barnepass",
-              "verdi": "Årsak"
-            },
-            {
-              "label": "Ordninger",
-              "verdiliste": [
-                {
-                  "label": "Hva slags barnepassordning?",
-                  "verdi": "En"
-                },
-                {
-                  "label": "Navn",
-                  "verdi": "navn"
-                },
-                {
-                  "label": "Periode",
-                  "verdi": "Fra januar 2020 til juli 2020"
-                },
-                {
-                  "label": "Periode",
-                  "verdi": "Fra 12.01.2020 til 15.02.2020"
-                },
-                {
-                  "label": "Beløp",
-                  "verdi": "1000,21"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Arbeid, utdanning og andre aktiviteter",
-      "verdiliste": [
-        {
-          "label": "Hvordan er arbeidssituasjonen din?",
-          "verdi": "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
-        },
-        {
-          "label": "Om arbeidsforholdet ditt",
-          "visningsVariant": "TABELL_ARBEIDSFORHOLD",
-          "verdiliste": [
-            {
-              "label": "Navn på arbeidsgiveren",
-              "verdi": "Palpatine"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "15"
-            },
-            {
-              "label": "Er stillingen fast eller midlertidig?",
-              "verdi": "Fast"
-            },
-            {
-              "label": "Har du en sluttdato?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når skal du slutte?",
-              "verdi": "18.11.2020"
-            }
-          ]
-        },
-        {
-          "label": "Om firmaet du driver",
-          "verdiliste": [
-            {
-              "label": "Navn på firma",
-              "verdi": "Bobs burgers"
-            },
-            {
-              "label": "Organisasjonsnummer",
-              "verdi": "987654321"
-            },
-            {
-              "label": "Når etablerte du firmaet?",
-              "verdi": "05.04.2018"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "150"
-            },
-            {
-              "label": "Hvordan ser arbeidsuken din ut?",
-              "verdi": "Veldig tung"
-            }
-          ]
-        },
-        {
-          "label": "Om virksomheten du etablerer",
-          "verdiliste": [
-            {
-              "label": "Beskriv virksomheten",
-              "verdi": "Den kommer til å revolusjonere verden"
-            }
-          ]
-        },
-        {
-          "label": "Når du er arbeidssøker",
-          "verdiliste": [
-            {
-              "label": "Er du registrert som arbeidssøker hos NAV?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
-              "verdi": "Nei"
-            },
-            {
-              "label": "Hvor ønsker du å søke arbeid?",
-              "verdi": "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
-            },
-            {
-              "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Utdanningen du skal ta",
-          "verdiliste": [
-            {
-              "label": "Skole/utdanningssted",
-              "verdi": "UiO"
-            },
-            {
-              "label": "Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Profesjonsstudium Informatikk"
-                },
-                {
-                  "label": "Når skal du være elev/student?",
-                  "verdi": "Fra 01.01.1999 til 01.10.2004"
-                }
-              ]
-            },
-            {
-              "label": "Er utdanningen offentlig eller privat?",
-              "verdi": "Offentlig"
-            },
-            {
-              "label": "Heltid, eller deltid",
-              "verdi": "Deltid"
-            },
-            {
-              "label": "Hvor mye skal du studere?",
-              "verdi": "300"
-            },
-            {
-              "label": "Hva er målet med utdanningen?",
-              "verdi": "Økonomisk selvstendighet"
-            },
-            {
-              "label": "Har du tatt utdanning etter grunnskolen?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Tidligere Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Master Fysikk"
-                },
-                {
-                  "label": "Når var du elev/student?",
-                  "verdi": "Fra januar 1999 til oktober 2004"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Når søker du stønad fra?",
-      "verdiliste": [
-        {
-          "label": "Søke fra bestemt mnd",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Fra måned",
-          "verdi": "august"
-        },
-        {
-          "label": "Fra år",
-          "verdi": "2018"
-        }
-      ]
-    },
-    {
-      "label": "Barnepassordning faktura",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Avtale barnepasser",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Arbeidstid",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Spesielle behov",
-      "verdiliste": [
-        {
-          "label": "harSendtInn",
-          "verdi": "Nei"
-        }
-      ]
-    },
-    {
-      "label": "Vedlegg",
-      "visningsVariant" : "VEDLEGG",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
-        }
-      ]
-    }
-  ]
+  "label" : "Søknad om stønad til barnetilsyn (NAV 15-00.02)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Opplysninger om adresse",
+    "verdiliste" : [ {
+      "label" : "Bor du på denne adressen?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Har du meldt adresseendring til folkeregisteret",
+      "verdi" : "Ja"
+    }, {
+      "label" : "DokumentasjonForAdresseendring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barn",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    }, {
+      "label" : "Skal ha barnepass",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Barnepass",
+      "verdiliste" : [ {
+        "label" : "Årsak Barnepass",
+        "verdi" : "Årsak"
+      }, {
+        "label" : "Ordninger",
+        "verdiliste" : [ {
+          "label" : "Hva slags barnepassordning?",
+          "verdi" : "En"
+        }, {
+          "label" : "Navn",
+          "verdi" : "navn"
+        }, {
+          "label" : "Periode",
+          "verdi" : "Fra januar 2020 til juli 2020"
+        }, {
+          "label" : "Periode",
+          "verdi" : "Fra 12.01.2020 til 15.02.2020"
+        }, {
+          "label" : "Beløp",
+          "verdi" : "1000,21"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Hvordan er arbeidssituasjonen din?",
+      "verdi" : "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
+    }, {
+      "label" : "Om arbeidsforholdet ditt",
+      "visningsVariant" : "TABELL_ARBEIDSFORHOLD",
+      "verdiliste" : [ {
+        "label" : "Navn på arbeidsgiveren",
+        "verdi" : "Palpatine"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "15"
+      }, {
+        "label" : "Er stillingen fast eller midlertidig?",
+        "verdi" : "Fast"
+      }, {
+        "label" : "Har du en sluttdato?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når skal du slutte?",
+        "verdi" : "18.11.2020"
+      } ]
+    }, {
+      "label" : "Om firmaet du driver",
+      "verdiliste" : [ {
+        "label" : "Navn på firma",
+        "verdi" : "Bobs burgers"
+      }, {
+        "label" : "Organisasjonsnummer",
+        "verdi" : "987654321"
+      }, {
+        "label" : "Når etablerte du firmaet?",
+        "verdi" : "05.04.2018"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "150"
+      }, {
+        "label" : "Hvordan ser arbeidsuken din ut?",
+        "verdi" : "Veldig tung"
+      } ]
+    }, {
+      "label" : "Om virksomheten du etablerer",
+      "verdiliste" : [ {
+        "label" : "Beskriv virksomheten",
+        "verdi" : "Den kommer til å revolusjonere verden"
+      } ]
+    }, {
+      "label" : "Når du er arbeidssøker",
+      "verdiliste" : [ {
+        "label" : "Er du registrert som arbeidssøker hos NAV?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
+        "verdi" : "Nei"
+      }, {
+        "label" : "Hvor ønsker du å søke arbeid?",
+        "verdi" : "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
+      }, {
+        "label" : "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      } ]
+    }, {
+      "label" : "Utdanningen du skal ta",
+      "verdiliste" : [ {
+        "label" : "Skole/utdanningssted",
+        "verdi" : "UiO"
+      }, {
+        "label" : "Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Profesjonsstudium Informatikk"
+        }, {
+          "label" : "Når skal du være elev/student?",
+          "verdi" : "Fra 01.01.1999 til 01.10.2004"
+        } ]
+      }, {
+        "label" : "Er utdanningen offentlig eller privat?",
+        "verdi" : "Offentlig"
+      }, {
+        "label" : "Heltid, eller deltid",
+        "verdi" : "Deltid"
+      }, {
+        "label" : "Hvor mye skal du studere?",
+        "verdi" : "300"
+      }, {
+        "label" : "Hva er målet med utdanningen?",
+        "verdi" : "Økonomisk selvstendighet"
+      }, {
+        "label" : "Har du tatt utdanning etter grunnskolen?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Tidligere Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Master Fysikk"
+        }, {
+          "label" : "Når var du elev/student?",
+          "verdi" : "Fra januar 1999 til oktober 2004"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Når søker du stønad fra?",
+    "verdiliste" : [ {
+      "label" : "Søke fra bestemt mnd",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Fra måned",
+      "verdi" : "august"
+    }, {
+      "label" : "Fra år",
+      "verdi" : "2018"
+    } ]
+  }, {
+    "label" : "Barnepassordning faktura",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Avtale barnepasser",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Arbeidstid",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Spesielle behov",
+    "verdiliste" : [ {
+      "label" : "harSendtInn",
+      "verdi" : "Nei"
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "visningsVariant" : "VEDLEGG",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_ettersending.json
+++ b/src/test/resources/json/pdf_generated_ettersending.json
@@ -1,30 +1,22 @@
 {
-  "label": "Ettersending",
-  "verdiliste": [ {
-      "label": "Ettersending av vedlegg",
-      "verdiliste": [
-        {
-          "label": "Stønadstype",
-          "verdi": "OVERGANGSSTØNAD"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "23118612345"
-        },
-        {
-          "label": "Dato mottatt",
-          "verdi": "01.05.2021 12:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Dokumenter vedlagt",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Lærlingkontrakt\n\nUtgifter til pass av barn"
-        }
-      ]
-    }
-  ]
+  "label" : "Ettersending",
+  "verdiliste" : [ {
+    "label" : "Ettersending av vedlegg",
+    "verdiliste" : [ {
+      "label" : "Stønadstype",
+      "verdi" : "OVERGANGSSTØNAD"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "23118612345"
+    }, {
+      "label" : "Dato mottatt",
+      "verdi" : "01.05.2021 12:00:00"
+    } ]
+  }, {
+    "label" : "Dokumenter vedlagt",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Lærlingkontrakt\n\nUtgifter til pass av barn"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_overgangsstønad.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad.json
@@ -19,7 +19,7 @@
       "verdi" : "Norsk"
     }, {
       "label" : "Adresse",
-      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+      "verdi" : "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
     }, {
       "label" : "Sivilstand",
       "verdi" : "Ugift"

--- a/src/test/resources/json/pdf_generated_overgangsstønad.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad.json
@@ -1,624 +1,437 @@
 {
-  "label": "Søknad om overgangsstønad (NAV 15-00.01)",
-  "verdiliste": [
-    {
-      "label": "detaljer",
-      "verdiliste": [
-        {
-          "label": "mottat",
-          "verdi": "01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Søker",
-      "verdiliste": [
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Navn",
-          "verdi": "Kari Nordmann"
-        },
-        {
-          "label": "Statsborgerskap",
-          "verdi": "Norsk"
-        },
-        {
-          "label": "Adresse",
-          "verdi": "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
-        },
-        {
-          "label": "Sivilstand",
-          "verdi": "Ugift"
-        }
-      ]
-    },
-    {
-      "label": "Opplysninger om adresse",
-      "verdiliste": [
-        {
-          "label": "Bor du på denne adressen?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Har du meldt adresseendring til folkeregisteret",
-          "verdi": "Ja"
-        },
-        {
-          "label": "DokumentasjonForAdresseendring",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Detaljer om sivilstand",
-      "verdiliste": [
-        {
-          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "giftIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når søkte dere eller reiste sak?",
-          "verdi": "23.12.2015"
-        },
-        {
-          "label": "Skilsmisse- eller separasjonsbevilling",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Hva er grunnen til at du er alene med barn?",
-          "verdi": "Endring i samværsordning"
-        },
-        {
-          "label": "Erklæring om samlivsbrudd",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dato for samlivsbrudd",
-          "verdi": "03.10.2014"
-        },
-        {
-          "label": "Når flyttet dere fra hverandre?",
-          "verdi": "04.10.2014"
-        },
-        {
-          "label": "Når skjedde endringen / når skal endringen skje?",
-          "verdi": "17.04.2013"
-        }
-      ]
-    },
-    {
-      "label": "Opphold i Norge",
-      "verdiliste": [
-        {
-          "label": "Oppholder du deg i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Har du bodd i Norge de siste tre årene?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Utenlandsopphold",
-          "verdiliste": [
-            {
-              "label": "Fra",
-              "verdi": "04.12.2012"
-            },
-            {
-              "label": "Til",
-              "verdi": "18.12.2012"
-            },
-            {
-              "label" : "I hvilket land oppholdt du deg?",
-              "verdi" : "Spania"
-            },
-            {
-              "label": "Hvorfor bodde du i utlandet?",
-              "verdi": "Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Bosituasjonen din",
-      "verdiliste": [
-        {
-          "label": "Deler du bolig med andre voksne?",
-          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label": "Om samboeren din",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        },
-        {
-          "label": "Når flyttet dere sammen?",
-          "verdi": "12.08.2018"
-        }
-      ]
-    },
-    {
-      "label": "Sivilstandsplaner",
-      "verdiliste": [
-        {
-          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når skal dette skje?",
-          "verdi": "15.04.2021"
-        },
-        {
-          "label": "Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Barna dine",
-      "verdiliste": [
-        {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
-            },
-            {
-              "label": "Erklæring om samlivsbrudd",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Arbeid, utdanning og andre aktiviteter",
-      "verdiliste": [
-        {
-          "label": "Hvordan er arbeidssituasjonen din?",
-          "verdi": "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
-        },
-        {
-          "label": "Om arbeidsforholdet ditt",
-          "verdiliste": [
-            {
-              "label": "Navn på arbeidsgiveren",
-              "verdi": "Palpatine"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "15"
-            },
-            {
-              "label": "Er stillingen fast eller midlertidig?",
-              "verdi": "Fast"
-            },
-            {
-              "label": "Har du en sluttdato?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når skal du slutte?",
-              "verdi": "18.11.2020"
-            }
-          ]
-        },
-        {
-          "label": "Om firmaet du driver",
-          "verdiliste": [
-            {
-              "label": "Navn på firma",
-              "verdi": "Bobs burgers"
-            },
-            {
-              "label": "Organisasjonsnummer",
-              "verdi": "987654321"
-            },
-            {
-              "label": "Når etablerte du firmaet?",
-              "verdi": "05.04.2018"
-            },
-            {
-              "label": "Hvor mye jobber du?",
-              "verdi": "150"
-            },
-            {
-              "label": "Hvordan ser arbeidsuken din ut?",
-              "verdi": "Veldig tung"
-            }
-          ]
-        },
-        {
-          "label": "Om virksomheten du etablerer",
-          "verdiliste": [
-            {
-              "label": "Beskriv virksomheten",
-              "verdi": "Den kommer til å revolusjonere verden"
-            }
-          ]
-        },
-        {
-          "label": "Når du er arbeidssøker",
-          "verdiliste": [
-            {
-              "label": "Er du registrert som arbeidssøker hos NAV?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
-              "verdi": "Nei"
-            },
-            {
-              "label": "Hvor ønsker du å søke arbeid?",
-              "verdi": "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
-            },
-            {
-              "label": "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Utdanningen du skal ta",
-          "verdiliste": [
-            {
-              "label": "Skole/utdanningssted",
-              "verdi": "UiO"
-            },
-            {
-              "label": "Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Profesjonsstudium Informatikk"
-                },
-                {
-                  "label": "Når skal du være elev/student?",
-                  "verdi": "Fra 01.01.1999 til 01.10.2004"
-                }
-              ]
-            },
-            {
-              "label": "Er utdanningen offentlig eller privat?",
-              "verdi": "Offentlig"
-            },
-            {
-              "label": "Heltid, eller deltid",
-              "verdi": "Deltid"
-            },
-            {
-              "label": "Hvor mye skal du studere?",
-              "verdi": "300"
-            },
-            {
-              "label": "Hva er målet med utdanningen?",
-              "verdi": "Økonomisk selvstendighet"
-            },
-            {
-              "label": "Har du tatt utdanning etter grunnskolen?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Tidligere Utdanning",
-              "verdiliste": [
-                {
-                  "label": "Linje/kurs/grad",
-                  "verdi": "Master Fysikk"
-                },
-                {
-                  "label": "Når var du elev/student?",
-                  "verdi": "Fra januar 1999 til oktober 2004"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Mer om situasjonen din",
-      "verdiliste": [
-        {
-          "label": "Gjelder noe av dette deg?",
-          "verdi": "Barnet mitt er sykt\n\nJeg har søkt om barnepass, men ikke fått plass enda\n\nJeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
-          "alternativer": "123 / 234 / 345"
-        },
-        {
-          "label": "Legeerklæring",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Legeattest for egen sykdom eller sykt barn",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Avslag på søknad om barnehageplass, skolefritidsordning e.l.",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dokumentasjon av særlig tilsynsbehov",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dokumentasjon av studieopptak",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Læringskontrakt",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Når skal du starte i ny jobb?",
-          "verdi": "16.12.2045"
-        },
-        {
-          "label": "Dokumentasjon av jobbtilbud",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Når skal du starte utdanningen?",
-          "verdi": "28.07.2025"
-        },
-        {
-          "label": "Har du sagt opp jobben eller redusert arbeidstiden de siste 6 månedene?",
-          "verdi": "Ja, jeg har sagt opp jobben eller tatt frivillig permisjon (ikke foreldrepermisjon)"
-        },
-        {
-          "label": "Hvorfor sa du opp?",
-          "verdi": "Sjefen var dum"
-        },
-        {
-          "label": "Når sa du opp?",
-          "verdi": "12.01.2014"
-        },
-        {
-          "label": "Dokumentasjon av arbeidsforhold",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Når søker du stønad fra?",
-      "verdiliste": [
-        {
-          "label": "Søke fra bestemt mnd",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Fra måned",
-          "verdi": "august"
-        },
-        {
-          "label": "Fra år",
-          "verdi": "2018"
-        }
-      ]
-    },
-    {
-      "label": "Vedlegg",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
-        }
-      ]
-    }
-  ]
+  "label" : "Søknad om overgangsstønad (NAV 15-00.01)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Opplysninger om adresse",
+    "verdiliste" : [ {
+      "label" : "Bor du på denne adressen?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Har du meldt adresseendring til folkeregisteret",
+      "verdi" : "Ja"
+    }, {
+      "label" : "DokumentasjonForAdresseendring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barna dine",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Hvordan er arbeidssituasjonen din?",
+      "verdi" : "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
+    }, {
+      "label" : "Om arbeidsforholdet ditt",
+      "verdiliste" : [ {
+        "label" : "Navn på arbeidsgiveren",
+        "verdi" : "Palpatine"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "15"
+      }, {
+        "label" : "Er stillingen fast eller midlertidig?",
+        "verdi" : "Fast"
+      }, {
+        "label" : "Har du en sluttdato?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når skal du slutte?",
+        "verdi" : "18.11.2020"
+      } ]
+    }, {
+      "label" : "Om firmaet du driver",
+      "verdiliste" : [ {
+        "label" : "Navn på firma",
+        "verdi" : "Bobs burgers"
+      }, {
+        "label" : "Organisasjonsnummer",
+        "verdi" : "987654321"
+      }, {
+        "label" : "Når etablerte du firmaet?",
+        "verdi" : "05.04.2018"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "150"
+      }, {
+        "label" : "Hvordan ser arbeidsuken din ut?",
+        "verdi" : "Veldig tung"
+      } ]
+    }, {
+      "label" : "Om virksomheten du etablerer",
+      "verdiliste" : [ {
+        "label" : "Beskriv virksomheten",
+        "verdi" : "Den kommer til å revolusjonere verden"
+      } ]
+    }, {
+      "label" : "Når du er arbeidssøker",
+      "verdiliste" : [ {
+        "label" : "Er du registrert som arbeidssøker hos NAV?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
+        "verdi" : "Nei"
+      }, {
+        "label" : "Hvor ønsker du å søke arbeid?",
+        "verdi" : "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
+      }, {
+        "label" : "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      } ]
+    }, {
+      "label" : "Utdanningen du skal ta",
+      "verdiliste" : [ {
+        "label" : "Skole/utdanningssted",
+        "verdi" : "UiO"
+      }, {
+        "label" : "Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Profesjonsstudium Informatikk"
+        }, {
+          "label" : "Når skal du være elev/student?",
+          "verdi" : "Fra 01.01.1999 til 01.10.2004"
+        } ]
+      }, {
+        "label" : "Er utdanningen offentlig eller privat?",
+        "verdi" : "Offentlig"
+      }, {
+        "label" : "Heltid, eller deltid",
+        "verdi" : "Deltid"
+      }, {
+        "label" : "Hvor mye skal du studere?",
+        "verdi" : "300"
+      }, {
+        "label" : "Hva er målet med utdanningen?",
+        "verdi" : "Økonomisk selvstendighet"
+      }, {
+        "label" : "Har du tatt utdanning etter grunnskolen?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Tidligere Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Master Fysikk"
+        }, {
+          "label" : "Når var du elev/student?",
+          "verdi" : "Fra januar 1999 til oktober 2004"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Mer om situasjonen din",
+    "verdiliste" : [ {
+      "label" : "Gjelder noe av dette deg?",
+      "verdi" : "Barnet mitt er sykt\n\nJeg har søkt om barnepass, men ikke fått plass enda\n\nJeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
+      "alternativer" : "123 / 234 / 345"
+    }, {
+      "label" : "Legeerklæring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Legeattest for egen sykdom eller sykt barn",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Avslag på søknad om barnehageplass, skolefritidsordning e.l.",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dokumentasjon av særlig tilsynsbehov",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dokumentasjon av studieopptak",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Læringskontrakt",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Når skal du starte i ny jobb?",
+      "verdi" : "16.12.2045"
+    }, {
+      "label" : "Dokumentasjon av jobbtilbud",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Når skal du starte utdanningen?",
+      "verdi" : "28.07.2025"
+    }, {
+      "label" : "Har du sagt opp jobben eller redusert arbeidstiden de siste 6 månedene?",
+      "verdi" : "Ja, jeg har sagt opp jobben eller tatt frivillig permisjon (ikke foreldrepermisjon)"
+    }, {
+      "label" : "Hvorfor sa du opp?",
+      "verdi" : "Sjefen var dum"
+    }, {
+      "label" : "Når sa du opp?",
+      "verdi" : "12.01.2014"
+    }, {
+      "label" : "Dokumentasjon av arbeidsforhold",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Når søker du stønad fra?",
+    "verdiliste" : [ {
+      "label" : "Søke fra bestemt mnd",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Fra måned",
+      "verdi" : "august"
+    }, {
+      "label" : "Fra år",
+      "verdi" : "2018"
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_overgangsstønad_med_typer.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad_med_typer.json
@@ -1,628 +1,441 @@
 {
-  "label":"Søknad om overgangsstønad (NAV 15-00.01)",
-  "verdiliste":[
-    {
-      "label":"detaljer",
-      "verdiliste":[
-        {
-          "label":"mottat",
-          "verdi":"01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label":"Søker",
-      "verdiliste":[
-        {
-          "label":"Fødselsnummer",
-          "verdi":"03125462714"
-        },
-        {
-          "label":"Navn",
-          "verdi":"Kari Nordmann"
-        },
-        {
-          "label":"Statsborgerskap",
-          "verdi":"Norsk"
-        },
-        {
-          "label":"Adresse",
-          "verdi":"Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
-        },
-        {
-          "label":"Sivilstand",
-          "verdi":"Ugift"
-        }
-      ]
-    },
-    {
-      "label":"Opplysninger om adresse",
-      "verdiliste":[
-        {
-          "label":"Bor du på denne adressen?",
-          "verdi":"Nei"
-        },
-        {
-          "label":"Har du meldt adresseendring til folkeregisteret",
-          "verdi":"Ja"
-        },
-        {
-          "label":"DokumentasjonForAdresseendring",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Detaljer om sivilstand",
-      "verdiliste":[
-        {
-          "label":"Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi":"Ja"
-        },
-        {
-          "label":"giftIUtlandetDokumentasjon",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi":"Ja"
-        },
-        {
-          "label":"separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Når søkte dere eller reiste sak?",
-          "verdi":"23.12.2015"
-        },
-        {
-          "label":"Skilsmisse- eller separasjonsbevilling",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Hva er grunnen til at du er alene med barn?",
-          "verdi":"Endring i samværsordning"
-        },
-        {
-          "label":"Erklæring om samlivsbrudd",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Dato for samlivsbrudd",
-          "verdi":"03.10.2014"
-        },
-        {
-          "label":"Når flyttet dere fra hverandre?",
-          "verdi":"04.10.2014"
-        },
-        {
-          "label":"Når skjedde endringen / når skal endringen skje?",
-          "verdi":"17.04.2013"
-        }
-      ]
-    },
-    {
-      "label":"Opphold i Norge",
-      "verdiliste":[
-        {
-          "label":"Oppholder du deg i Norge?",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Har du bodd i Norge de siste tre årene?",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Utenlandsopphold",
-          "verdiliste":[
-            {
-              "label":"Fra",
-              "verdi":"04.12.2012"
-            },
-            {
-              "label":"Til",
-              "verdi":"18.12.2012"
-            },
-            {
-              "label":"I hvilket land oppholdt du deg?",
-              "verdi":"Spania"
-            },
-            {
-              "label":"Hvorfor bodde du i utlandet?",
-              "verdi":"Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Bosituasjonen din",
-      "verdiliste":[
-        {
-          "label":"Deler du bolig med andre voksne?",
-          "verdi":"Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label":"Om samboeren din",
-          "verdiliste":[
-            {
-              "label":"Navn",
-              "verdi":"Bob Burger"
-            },
-            {
-              "label":"Fødselsdato",
-              "verdi":"18.02.1992"
-            }
-          ]
-        },
-        {
-          "label":"Når flyttet dere sammen?",
-          "verdi":"12.08.2018"
-        }
-      ]
-    },
-    {
-      "label":"Sivilstandsplaner",
-      "verdiliste":[
-        {
-          "label":"Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Når skal dette skje?",
-          "verdi":"15.04.2021"
-        },
-        {
-          "label":"Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste":[
-            {
-              "label":"Navn",
-              "verdi":"Bob Burger"
-            },
-            {
-              "label":"Fødselsdato",
-              "verdi":"18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Barna dine",
-      "visningsVariant":"TABELL_BARN",
-      "verdiliste":[
-        {
-          "label":"Barnets fulle navn, hvis dette er bestemt",
-          "verdi":"Sorgløs"
-        },
-        {
-          "label":"Fødselsnummer",
-          "verdi":"03125462714"
-        },
-        {
-          "label":"Skal ha samme adresse",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Ikke registrert på søkers adresse",
-          "verdi":"Nei"
-        },
-        {
-          "label":"Er barnet født?",
-          "verdi":"Nei"
-        },
-        {
-          "label":"Termindato",
-          "verdi":"16.05.2020"
-        },
-        {
-          "label":"Bekreftelse på ventet fødselsdato",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Barnets andre forelder",
-          "verdiliste":[
-            {
-              "label":"Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi":"Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label":"Samvær",
-          "verdiliste":[
-            {
-              "label":"Har den andre forelderen samvær med barnet",
-              "verdi":"Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label":"Har dere skriftlig samværsavtale for barnet?",
-              "verdi":"Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label":"Avtale om samvær",
-              "verdiliste":[
-                {
-                  "label":"harSendtInn",
-                  "verdi":"Nei"
-                }
-              ]
-            },
-            {
-              "label":"Skal barnet bo hos deg",
-              "verdiliste":[
-                {
-                  "label":"harSendtInn",
-                  "verdi":"Nei"
-                }
-              ]
-            },
-            {
-              "label":"Hvordan praktiserer dere samværet?",
-              "verdi":"Litt hver for oss"
-            },
-            {
-              "label":"Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi":"ja"
-            },
-            {
-              "label":"Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi":"Ekstra info?"
-            },
-            {
-              "label":"Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Når flyttet dere fra hverandre?",
-              "verdi":"21.07.2018"
-            },
-            {
-              "label":"Erklæring om samlivsbrudd",
-              "verdiliste":[
-                {
-                  "label":"harSendtInn",
-                  "verdi":"Nei"
-                }
-              ]
-            },
-            {
-              "label":"Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi":"Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label":"Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi":"Vi sees stadig vekk"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Arbeid, utdanning og andre aktiviteter",
-      "verdiliste":[
-        {
-          "label":"Hvordan er arbeidssituasjonen din?",
-          "verdi":"Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
-        },
-        {
-          "label":"Om arbeidsforholdet ditt",
-          "visningsVariant": "TABELL_ARBEIDSFORHOLD",
-          "verdiliste":[
-            {
-              "label":"Navn på arbeidsgiveren",
-              "verdi":"Palpatine"
-            },
-            {
-              "label":"Hvor mye jobber du?",
-              "verdi":"15"
-            },
-            {
-              "label":"Er stillingen fast eller midlertidig?",
-              "verdi":"Fast"
-            },
-            {
-              "label":"Har du en sluttdato?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Når skal du slutte?",
-              "verdi":"18.11.2020"
-            }
-          ]
-        },
-        {
-          "label":"Om firmaet du driver",
-          "verdiliste":[
-            {
-              "label":"Navn på firma",
-              "verdi":"Bobs burgers"
-            },
-            {
-              "label":"Organisasjonsnummer",
-              "verdi":"987654321"
-            },
-            {
-              "label":"Når etablerte du firmaet?",
-              "verdi":"05.04.2018"
-            },
-            {
-              "label":"Hvor mye jobber du?",
-              "verdi":"150"
-            },
-            {
-              "label":"Hvordan ser arbeidsuken din ut?",
-              "verdi":"Veldig tung"
-            }
-          ]
-        },
-        {
-          "label":"Om virksomheten du etablerer",
-          "verdiliste":[
-            {
-              "label":"Beskriv virksomheten",
-              "verdi":"Den kommer til å revolusjonere verden"
-            }
-          ]
-        },
-        {
-          "label":"Når du er arbeidssøker",
-          "verdiliste":[
-            {
-              "label":"Er du registrert som arbeidssøker hos NAV?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
-              "verdi":"Nei"
-            },
-            {
-              "label":"Hvor ønsker du å søke arbeid?",
-              "verdi":"Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
-            },
-            {
-              "label":"Ønsker du å stå som arbeidssøker til minst 50% stilling?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
-              "verdiliste":[
-                {
-                  "label":"harSendtInn",
-                  "verdi":"Nei"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "label":"Utdanningen du skal ta",
-          "verdiliste":[
-            {
-              "label":"Skole/utdanningssted",
-              "verdi":"UiO"
-            },
-            {
-              "label":"Utdanning",
-              "verdiliste":[
-                {
-                  "label":"Linje/kurs/grad",
-                  "verdi":"Profesjonsstudium Informatikk"
-                },
-                {
-                  "label":"Når skal du være elev/student?",
-                  "verdi":"Fra 01.01.1999 til 01.10.2004"
-                }
-              ]
-            },
-            {
-              "label":"Er utdanningen offentlig eller privat?",
-              "verdi":"Offentlig"
-            },
-            {
-              "label":"Heltid, eller deltid",
-              "verdi":"Deltid"
-            },
-            {
-              "label":"Hvor mye skal du studere?",
-              "verdi":"300"
-            },
-            {
-              "label":"Hva er målet med utdanningen?",
-              "verdi":"Økonomisk selvstendighet"
-            },
-            {
-              "label":"Har du tatt utdanning etter grunnskolen?",
-              "verdi":"Ja"
-            },
-            {
-              "label":"Tidligere Utdanning",
-              "verdiliste":[
-                {
-                  "label":"Linje/kurs/grad",
-                  "verdi":"Master Fysikk"
-                },
-                {
-                  "label":"Når var du elev/student?",
-                  "verdi":"Fra januar 1999 til oktober 2004"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Mer om situasjonen din",
-      "verdiliste":[
-        {
-          "label":"Gjelder noe av dette deg?",
-          "visningsVariant" : "PUNKTLISTE",
-          "verdi":"Barnet mitt er sykt\n\nJeg har søkt om barnepass, men ikke fått plass enda\n\nJeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
-          "alternativer":"123 / 234 / 345"
-        },
-        {
-          "label":"Legeerklæring",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Legeattest for egen sykdom eller sykt barn",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Avslag på søknad om barnehageplass, skolefritidsordning e.l.",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Dokumentasjon av særlig tilsynsbehov",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Dokumentasjon av studieopptak",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Læringskontrakt",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Når skal du starte i ny jobb?",
-          "verdi":"16.12.2045"
-        },
-        {
-          "label":"Dokumentasjon av jobbtilbud",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        },
-        {
-          "label":"Når skal du starte utdanningen?",
-          "verdi":"28.07.2025"
-        },
-        {
-          "label":"Har du sagt opp jobben eller redusert arbeidstiden de siste 6 månedene?",
-          "verdi":"Ja, jeg har sagt opp jobben eller tatt frivillig permisjon (ikke foreldrepermisjon)"
-        },
-        {
-          "label":"Hvorfor sa du opp?",
-          "verdi":"Sjefen var dum"
-        },
-        {
-          "label":"Når sa du opp?",
-          "verdi":"12.01.2014"
-        },
-        {
-          "label":"Dokumentasjon av arbeidsforhold",
-          "verdiliste":[
-            {
-              "label":"harSendtInn",
-              "verdi":"Nei"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label":"Når søker du stønad fra?",
-      "verdiliste":[
-        {
-          "label":"Søke fra bestemt mnd",
-          "verdi":"Ja"
-        },
-        {
-          "label":"Fra måned",
-          "verdi":"august"
-        },
-        {
-          "label":"Fra år",
-          "verdi":"2018"
-        }
-      ]
-    },
-    {
-      "label":"Vedlegg",
-      "visningsVariant" : "VEDLEGG",
-      "verdiliste":[
-        {
-          "label":"Vedlegg",
-          "verdi":"Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
-        }
-      ]
-    }
-  ]
+  "label" : "Søknad om overgangsstønad (NAV 15-00.01)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Opplysninger om adresse",
+    "verdiliste" : [ {
+      "label" : "Bor du på denne adressen?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Har du meldt adresseendring til folkeregisteret",
+      "verdi" : "Ja"
+    }, {
+      "label" : "DokumentasjonForAdresseendring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barna dine",
+    "visningsVariant" : "TABELL_BARN",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Hvordan er arbeidssituasjonen din?",
+      "verdi" : "Jeg er hjemme med barn under 1 år\n\nJeg er i arbeid\n\nJeg er selvstendig næringsdrivende eller frilanser"
+    }, {
+      "label" : "Om arbeidsforholdet ditt",
+      "visningsVariant" : "TABELL_ARBEIDSFORHOLD",
+      "verdiliste" : [ {
+        "label" : "Navn på arbeidsgiveren",
+        "verdi" : "Palpatine"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "15"
+      }, {
+        "label" : "Er stillingen fast eller midlertidig?",
+        "verdi" : "Fast"
+      }, {
+        "label" : "Har du en sluttdato?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når skal du slutte?",
+        "verdi" : "18.11.2020"
+      } ]
+    }, {
+      "label" : "Om firmaet du driver",
+      "verdiliste" : [ {
+        "label" : "Navn på firma",
+        "verdi" : "Bobs burgers"
+      }, {
+        "label" : "Organisasjonsnummer",
+        "verdi" : "987654321"
+      }, {
+        "label" : "Når etablerte du firmaet?",
+        "verdi" : "05.04.2018"
+      }, {
+        "label" : "Hvor mye jobber du?",
+        "verdi" : "150"
+      }, {
+        "label" : "Hvordan ser arbeidsuken din ut?",
+        "verdi" : "Veldig tung"
+      } ]
+    }, {
+      "label" : "Om virksomheten du etablerer",
+      "verdiliste" : [ {
+        "label" : "Beskriv virksomheten",
+        "verdi" : "Den kommer til å revolusjonere verden"
+      } ]
+    }, {
+      "label" : "Når du er arbeidssøker",
+      "verdiliste" : [ {
+        "label" : "Er du registrert som arbeidssøker hos NAV?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Er du villig til å ta imot tilbud om arbeid eller arbeidsmarkedstiltak?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Kan du begynne i arbeid senest én uke etter at du har fått tilbud om jobb?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Har du eller kan du skaffe barnepass senest innen en uke etter at du har fått tilbud om jobb eller arbeidsmarkedstiltak?",
+        "verdi" : "Nei"
+      }, {
+        "label" : "Hvor ønsker du å søke arbeid?",
+        "verdi" : "Kun i bodistriktet mitt, ikke mer enn 1 times reisevei"
+      }, {
+        "label" : "Ønsker du å stå som arbeidssøker til minst 50% stilling?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Dokumentasjon - ikke villig til å ta import tilbud om arbeid",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      } ]
+    }, {
+      "label" : "Utdanningen du skal ta",
+      "verdiliste" : [ {
+        "label" : "Skole/utdanningssted",
+        "verdi" : "UiO"
+      }, {
+        "label" : "Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Profesjonsstudium Informatikk"
+        }, {
+          "label" : "Når skal du være elev/student?",
+          "verdi" : "Fra 01.01.1999 til 01.10.2004"
+        } ]
+      }, {
+        "label" : "Er utdanningen offentlig eller privat?",
+        "verdi" : "Offentlig"
+      }, {
+        "label" : "Heltid, eller deltid",
+        "verdi" : "Deltid"
+      }, {
+        "label" : "Hvor mye skal du studere?",
+        "verdi" : "300"
+      }, {
+        "label" : "Hva er målet med utdanningen?",
+        "verdi" : "Økonomisk selvstendighet"
+      }, {
+        "label" : "Har du tatt utdanning etter grunnskolen?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Tidligere Utdanning",
+        "verdiliste" : [ {
+          "label" : "Linje/kurs/grad",
+          "verdi" : "Master Fysikk"
+        }, {
+          "label" : "Når var du elev/student?",
+          "verdi" : "Fra januar 1999 til oktober 2004"
+        } ]
+      } ]
+    } ]
+  }, {
+    "label" : "Mer om situasjonen din",
+    "verdiliste" : [ {
+      "label" : "Gjelder noe av dette deg?",
+      "visningsVariant" : "PUNKTLISTE",
+      "verdi" : "Barnet mitt er sykt\n\nJeg har søkt om barnepass, men ikke fått plass enda\n\nJeg har barn som har behov for særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer",
+      "alternativer" : "123 / 234 / 345"
+    }, {
+      "label" : "Legeerklæring",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Legeattest for egen sykdom eller sykt barn",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Avslag på søknad om barnehageplass, skolefritidsordning e.l.",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dokumentasjon av særlig tilsynsbehov",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dokumentasjon av studieopptak",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Læringskontrakt",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Når skal du starte i ny jobb?",
+      "verdi" : "16.12.2045"
+    }, {
+      "label" : "Dokumentasjon av jobbtilbud",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Når skal du starte utdanningen?",
+      "verdi" : "28.07.2025"
+    }, {
+      "label" : "Har du sagt opp jobben eller redusert arbeidstiden de siste 6 månedene?",
+      "verdi" : "Ja, jeg har sagt opp jobben eller tatt frivillig permisjon (ikke foreldrepermisjon)"
+    }, {
+      "label" : "Hvorfor sa du opp?",
+      "verdi" : "Sjefen var dum"
+    }, {
+      "label" : "Når sa du opp?",
+      "verdi" : "12.01.2014"
+    }, {
+      "label" : "Dokumentasjon av arbeidsforhold",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    } ]
+  }, {
+    "label" : "Når søker du stønad fra?",
+    "verdiliste" : [ {
+      "label" : "Søke fra bestemt mnd",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Fra måned",
+      "verdi" : "august"
+    }, {
+      "label" : "Fra år",
+      "verdi" : "2018"
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "visningsVariant" : "VEDLEGG",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Dokumentasjon på at du er syk\n\nDokumentasjon på at du er syk\n\nDokumentasjon på at kan arbeide"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_skolepenger.json
+++ b/src/test/resources/json/pdf_generated_skolepenger.json
@@ -1,278 +1,394 @@
 {
-  "label" : "Søknad om stønad til skolepenger (NAV 15-00.04)",
-  "verdiliste" : [ {
-    "label" : "detaljer",
-    "verdiliste" : [ {
-      "label" : "mottat",
-      "verdi" : "01.01.2020 00:00:00"
-    } ]
-  }, {
-    "label" : "Søker",
-    "verdiliste" : [ {
-      "label" : "Fødselsnummer",
-      "verdi" : "03125462714"
-    }, {
-      "label" : "Navn",
-      "verdi" : "Kari Nordmann"
-    }, {
-      "label" : "Statsborgerskap",
-      "verdi" : "Norsk"
-    }, {
-      "label" : "Adresse",
-      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
-    }, {
-      "label" : "Sivilstand",
-      "verdi" : "Ugift"
-    } ]
-  }, {
-    "label" : "Detaljer om sivilstand",
-    "verdiliste" : [ {
-      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "giftIUtlandetDokumentasjon",
-      "verdiliste" : [ {
-        "label" : "harSendtInn",
-        "verdi" : "Nei"
-      } ]
-    }, {
-      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
-      "verdiliste" : [ {
-        "label" : "harSendtInn",
-        "verdi" : "Nei"
-      } ]
-    }, {
-      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Når søkte dere eller reiste sak?",
-      "verdi" : "23.12.2015"
-    }, {
-      "label" : "Skilsmisse- eller separasjonsbevilling",
-      "verdiliste" : [ {
-        "label" : "harSendtInn",
-        "verdi" : "Nei"
-      } ]
-    }, {
-      "label" : "Hva er grunnen til at du er alene med barn?",
-      "verdi" : "Endring i samværsordning"
-    }, {
-      "label" : "Erklæring om samlivsbrudd",
-      "verdiliste" : [ {
-        "label" : "harSendtInn",
-        "verdi" : "Nei"
-      } ]
-    }, {
-      "label" : "Dato for samlivsbrudd",
-      "verdi" : "03.10.2014"
-    }, {
-      "label" : "Når flyttet dere fra hverandre?",
-      "verdi" : "04.10.2014"
-    }, {
-      "label" : "Når skjedde endringen / når skal endringen skje?",
-      "verdi" : "17.04.2013"
-    } ]
-  }, {
-    "label" : "Opphold i Norge",
-    "verdiliste" : [ {
-      "label" : "Oppholder du deg i Norge?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Har du bodd i Norge de siste tre årene?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Utenlandsopphold",
-      "verdiliste" : [ {
-        "label" : "Fra",
-        "verdi" : "04.12.2012"
-      }, {
-        "label" : "Til",
-        "verdi" : "18.12.2012"
-      }, {
-        "label" : "I hvilket land oppholdt du deg?",
-        "verdi" : "Spania"
-      }, {
-        "label" : "Hvorfor bodde du i utlandet?",
-        "verdi" : "Granca, Granca, Granca"
-      } ]
-    } ]
-  }, {
-    "label" : "Bosituasjonen din",
-    "verdiliste" : [ {
-      "label" : "Deler du bolig med andre voksne?",
-      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-    }, {
-      "label" : "Om samboeren din",
-      "verdiliste" : [ {
-        "label" : "Navn",
-        "verdi" : "Bob Burger"
-      }, {
-        "label" : "Fødselsdato",
-        "verdi" : "18.02.1992"
-      } ]
-    }, {
-      "label" : "Når flyttet dere sammen?",
-      "verdi" : "12.08.2018"
-    } ]
-  }, {
-    "label" : "Sivilstandsplaner",
-    "verdiliste" : [ {
-      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Når skal dette skje?",
-      "verdi" : "15.04.2021"
-    }, {
-      "label" : "Hvem skal du gifte deg eller bli samboer med?",
-      "verdiliste" : [ {
-        "label" : "Navn",
-        "verdi" : "Bob Burger"
-      }, {
-        "label" : "Fødselsdato",
-        "verdi" : "18.02.1992"
-      } ]
-    } ]
-  }, {
-    "label" : "Barn",
-    "verdiliste" : [ {
-      "label" : "Barnets fulle navn, hvis dette er bestemt",
-      "verdi" : "Sorgløs"
-    }, {
-      "label" : "Fødselsnummer",
-      "verdi" : "03125462714"
-    }, {
-      "label" : "Skal ha samme adresse",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Ikke registrert på søkers adresse",
-      "verdi" : "Nei"
-    }, {
-      "label" : "Er barnet født?",
-      "verdi" : "Nei"
-    }, {
-      "label" : "Termindato",
-      "verdi" : "16.05.2020"
-    }, {
-      "label" : "Bekreftelse på ventet fødselsdato",
-      "verdiliste" : [ {
-        "label" : "harSendtInn",
-        "verdi" : "Nei"
-      } ]
-    }, {
-      "label" : "Barnets andre forelder",
-      "verdiliste" : [ {
-        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
-        "verdi" : "Fordi jeg ikke liker hen."
-      } ]
-    }, {
-      "label" : "Samvær",
-      "verdiliste" : [ {
-        "label" : "Har den andre forelderen samvær med barnet",
-        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
-      }, {
-        "label" : "Har dere skriftlig samværsavtale for barnet?",
-        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-      }, {
-        "label" : "Avtale om samvær",
-        "verdiliste" : [ {
-          "label" : "harSendtInn",
-          "verdi" : "Nei"
-        } ]
-      }, {
-        "label" : "Skal barnet bo hos deg",
-        "verdiliste" : [ {
-          "label" : "harSendtInn",
-          "verdi" : "Nei"
-        } ]
-      }, {
-        "label" : "Hvordan praktiserer dere samværet?",
-        "verdi" : "Litt hver for oss"
-      }, {
-        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-        "verdi" : "ja"
-      }, {
-        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-        "verdi" : "Ekstra info?"
-      }, {
-        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-        "verdi" : "Ja"
-      }, {
-        "label" : "Når flyttet dere fra hverandre?",
-        "verdi" : "21.07.2018"
-      }, {
-        "label" : "Erklæring om samlivsbrudd",
-        "verdiliste" : [ {
-          "label" : "harSendtInn",
-          "verdi" : "Nei"
-        } ]
-      }, {
-        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
-        "verdi" : "Vi møtes også uten at barnet er til stede"
-      }, {
-        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-        "verdi" : "Vi sees stadig vekk"
-      } ]
-    } ]
-  }, {
-    "label" : "Arbeid, utdanning og andre aktiviteter",
-    "verdiliste" : [ {
-      "label" : "Skole/utdanningssted",
-      "verdi" : "UiO"
-    }, {
-      "label" : "Utdanning",
-      "verdiliste" : [ {
-        "label" : "Linje/kurs/grad",
-        "verdi" : "Profesjonsstudium Informatikk"
-      }, {
-        "label" : "Når skal du være elev/student?",
-        "verdi" : "Fra januar 1999 til oktober 2004"
-      } ]
-    }, {
-      "label" : "Utdanning",
-      "verdiliste" : [ {
-        "label" : "Linje/kurs/grad",
-        "verdi" : "Profesjonsstudium Informatikk"
-      }, {
-        "label" : "Når skal du være elev/student?",
-        "verdi" : "Fra 01.01.1999 til 01.10.2004"
-      } ]
-    }, {
-      "label" : "Er utdanningen offentlig eller privat?",
-      "verdi" : "Offentlig"
-    }, {
-      "label" : "Heltid, eller deltid",
-      "verdi" : "Deltid"
-    }, {
-      "label" : "Hvor mye skal du studere?",
-      "verdi" : "300"
-    }, {
-      "label" : "Hva er målet med utdanningen?",
-      "verdi" : "Økonomisk selvstendighet"
-    }, {
-      "label" : "Har du tatt utdanning etter grunnskolen?",
-      "verdi" : "Ja"
-    }, {
-      "label" : "Tidligere Utdanning",
-      "verdiliste" : [ {
-        "label" : "Linje/kurs/grad",
-        "verdi" : "Master Fysikk"
-      }, {
-        "label" : "Når var du elev/student?",
-        "verdi" : "Fra januar 1999 til oktober 2004"
-      } ]
-    } ]
-  }, {
-    "label" : "Vedlegg",
-    "verdiliste" : [ {
-      "label" : "Vedlegg",
-      "verdi" : "Utgifter til utdanning"
-    } ]
-  } ],
-  "pdfConfig" : {
-    "harInnholdsfortegnelse" : true,
-    "språk" : "NB"
+  "label": "Søknad om stønad til skolepenger (NAV 15-00.04)",
+  "verdiliste": [
+    {
+      "label": "detaljer",
+      "verdiliste": [
+        {
+          "label": "mottat",
+          "verdi": "01.01.2020 00:00:00"
+        }
+      ]
+    },
+    {
+      "label": "Søker",
+      "verdiliste": [
+        {
+          "label": "Fødselsnummer",
+          "verdi": "03125462714"
+        },
+        {
+          "label": "Navn",
+          "verdi": "Kari Nordmann"
+        },
+        {
+          "label": "Statsborgerskap",
+          "verdi": "Norsk"
+        },
+        {
+          "label": "Adresse",
+          "verdi": "Jerpefaret 5C\n1440 Drøbak\nNorge"
+        },
+        {
+          "label": "Sivilstand",
+          "verdi": "Ugift"
+        }
+      ]
+    },
+    {
+      "label": "Detaljer om sivilstand",
+      "verdiliste": [
+        {
+          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "giftIUtlandetDokumentasjon",
+          "verdiliste": [
+            {
+              "label": "harSendtInn",
+              "verdi": "Nei"
+            }
+          ]
+        },
+        {
+          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "separertEllerSkiltIUtlandetDokumentasjon",
+          "verdiliste": [
+            {
+              "label": "harSendtInn",
+              "verdi": "Nei"
+            }
+          ]
+        },
+        {
+          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Når søkte dere eller reiste sak?",
+          "verdi": "23.12.2015"
+        },
+        {
+          "label": "Skilsmisse- eller separasjonsbevilling",
+          "verdiliste": [
+            {
+              "label": "harSendtInn",
+              "verdi": "Nei"
+            }
+          ]
+        },
+        {
+          "label": "Hva er grunnen til at du er alene med barn?",
+          "verdi": "Endring i samværsordning"
+        },
+        {
+          "label": "Erklæring om samlivsbrudd",
+          "verdiliste": [
+            {
+              "label": "harSendtInn",
+              "verdi": "Nei"
+            }
+          ]
+        },
+        {
+          "label": "Dato for samlivsbrudd",
+          "verdi": "03.10.2014"
+        },
+        {
+          "label": "Når flyttet dere fra hverandre?",
+          "verdi": "04.10.2014"
+        },
+        {
+          "label": "Når skjedde endringen / når skal endringen skje?",
+          "verdi": "17.04.2013"
+        }
+      ]
+    },
+    {
+      "label": "Opphold i Norge",
+      "verdiliste": [
+        {
+          "label": "Oppholder du deg i Norge?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Har du bodd i Norge de siste tre årene?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Utenlandsopphold",
+          "verdiliste": [
+            {
+              "label": "Fra",
+              "verdi": "04.12.2012"
+            },
+            {
+              "label": "Til",
+              "verdi": "18.12.2012"
+            },
+            {
+              "label": "I hvilket land oppholdt du deg?",
+              "verdi": "Spania"
+            },
+            {
+              "label": "Hvorfor bodde du i utlandet?",
+              "verdi": "Granca, Granca, Granca"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Bosituasjonen din",
+      "verdiliste": [
+        {
+          "label": "Deler du bolig med andre voksne?",
+          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+        },
+        {
+          "label": "Om samboeren din",
+          "verdiliste": [
+            {
+              "label": "Navn",
+              "verdi": "Bob Burger"
+            },
+            {
+              "label": "Fødselsdato",
+              "verdi": "18.02.1992"
+            }
+          ]
+        },
+        {
+          "label": "Når flyttet dere sammen?",
+          "verdi": "12.08.2018"
+        }
+      ]
+    },
+    {
+      "label": "Sivilstandsplaner",
+      "verdiliste": [
+        {
+          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Når skal dette skje?",
+          "verdi": "15.04.2021"
+        },
+        {
+          "label": "Hvem skal du gifte deg eller bli samboer med?",
+          "verdiliste": [
+            {
+              "label": "Navn",
+              "verdi": "Bob Burger"
+            },
+            {
+              "label": "Fødselsdato",
+              "verdi": "18.02.1992"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Barn",
+      "verdiliste": [
+        {
+          "label": "Barnets fulle navn, hvis dette er bestemt",
+          "verdi": "Sorgløs"
+        },
+        {
+          "label": "Fødselsnummer",
+          "verdi": "03125462714"
+        },
+        {
+          "label": "Skal ha samme adresse",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Ikke registrert på søkers adresse",
+          "verdi": "Nei"
+        },
+        {
+          "label": "Er barnet født?",
+          "verdi": "Nei"
+        },
+        {
+          "label": "Termindato",
+          "verdi": "16.05.2020"
+        },
+        {
+          "label": "Bekreftelse på ventet fødselsdato",
+          "verdiliste": [
+            {
+              "label": "harSendtInn",
+              "verdi": "Nei"
+            }
+          ]
+        },
+        {
+          "label": "Barnets andre forelder",
+          "verdiliste": [
+            {
+              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
+              "verdi": "Fordi jeg ikke liker hen."
+            }
+          ]
+        },
+        {
+          "label": "Samvær",
+          "verdiliste": [
+            {
+              "label": "Har den andre forelderen samvær med barnet",
+              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
+            },
+            {
+              "label": "Har dere skriftlig samværsavtale for barnet?",
+              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+            },
+            {
+              "label": "Avtale om samvær",
+              "verdiliste": [
+                {
+                  "label": "harSendtInn",
+                  "verdi": "Nei"
+                }
+              ]
+            },
+            {
+              "label": "Skal barnet bo hos deg",
+              "verdiliste": [
+                {
+                  "label": "harSendtInn",
+                  "verdi": "Nei"
+                }
+              ]
+            },
+            {
+              "label": "Hvordan praktiserer dere samværet?",
+              "verdi": "Litt hver for oss"
+            },
+            {
+              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+              "verdi": "ja"
+            },
+            {
+              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+              "verdi": "Ekstra info?"
+            },
+            {
+              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+              "verdi": "Ja"
+            },
+            {
+              "label": "Når flyttet dere fra hverandre?",
+              "verdi": "21.07.2018"
+            },
+            {
+              "label": "Erklæring om samlivsbrudd",
+              "verdiliste": [
+                {
+                  "label": "harSendtInn",
+                  "verdi": "Nei"
+                }
+              ]
+            },
+            {
+              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
+              "verdi": "Vi møtes også uten at barnet er til stede"
+            },
+            {
+              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+              "verdi": "Vi sees stadig vekk"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Arbeid, utdanning og andre aktiviteter",
+      "verdiliste": [
+        {
+          "label": "Skole/utdanningssted",
+          "verdi": "UiO"
+        },
+        {
+          "label": "Utdanning",
+          "verdiliste": [
+            {
+              "label": "Linje/kurs/grad",
+              "verdi": "Profesjonsstudium Informatikk"
+            },
+            {
+              "label": "Når skal du være elev/student?",
+              "verdi": "Fra januar 1999 til oktober 2004"
+            }
+          ]
+        },
+        {
+          "label": "Utdanning",
+          "verdiliste": [
+            {
+              "label": "Linje/kurs/grad",
+              "verdi": "Profesjonsstudium Informatikk"
+            },
+            {
+              "label": "Når skal du være elev/student?",
+              "verdi": "Fra 01.01.1999 til 01.10.2004"
+            }
+          ]
+        },
+        {
+          "label": "Er utdanningen offentlig eller privat?",
+          "verdi": "Offentlig"
+        },
+        {
+          "label": "Heltid, eller deltid",
+          "verdi": "Deltid"
+        },
+        {
+          "label": "Hvor mye skal du studere?",
+          "verdi": "300"
+        },
+        {
+          "label": "Hva er målet med utdanningen?",
+          "verdi": "Økonomisk selvstendighet"
+        },
+        {
+          "label": "Har du tatt utdanning etter grunnskolen?",
+          "verdi": "Ja"
+        },
+        {
+          "label": "Tidligere Utdanning",
+          "verdiliste": [
+            {
+              "label": "Linje/kurs/grad",
+              "verdi": "Master Fysikk"
+            },
+            {
+              "label": "Når var du elev/student?",
+              "verdi": "Fra januar 1999 til oktober 2004"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Vedlegg",
+      "verdiliste": [
+        {
+          "label": "Vedlegg",
+          "verdi": "Utgifter til utdanning"
+        }
+      ]
+    }
+  ],
+  "pdfConfig": {
+    "harInnholdsfortegnelse": true,
+    "språk": "NB"
   }
 }

--- a/src/test/resources/json/pdf_generated_skolepenger.json
+++ b/src/test/resources/json/pdf_generated_skolepenger.json
@@ -1,394 +1,278 @@
 {
-  "label": "Søknad om stønad til skolepenger (NAV 15-00.04)",
-  "verdiliste": [
-    {
-      "label": "detaljer",
-      "verdiliste": [
-        {
-          "label": "mottat",
-          "verdi": "01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Søker",
-      "verdiliste": [
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Navn",
-          "verdi": "Kari Nordmann"
-        },
-        {
-          "label": "Statsborgerskap",
-          "verdi": "Norsk"
-        },
-        {
-          "label": "Adresse",
-          "verdi": "Jerpefaret 5C\n1440 Drøbak\nNorge"
-        },
-        {
-          "label": "Sivilstand",
-          "verdi": "Ugift"
-        }
-      ]
-    },
-    {
-      "label": "Detaljer om sivilstand",
-      "verdiliste": [
-        {
-          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "giftIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når søkte dere eller reiste sak?",
-          "verdi": "23.12.2015"
-        },
-        {
-          "label": "Skilsmisse- eller separasjonsbevilling",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Hva er grunnen til at du er alene med barn?",
-          "verdi": "Endring i samværsordning"
-        },
-        {
-          "label": "Erklæring om samlivsbrudd",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dato for samlivsbrudd",
-          "verdi": "03.10.2014"
-        },
-        {
-          "label": "Når flyttet dere fra hverandre?",
-          "verdi": "04.10.2014"
-        },
-        {
-          "label": "Når skjedde endringen / når skal endringen skje?",
-          "verdi": "17.04.2013"
-        }
-      ]
-    },
-    {
-      "label": "Opphold i Norge",
-      "verdiliste": [
-        {
-          "label": "Oppholder du deg i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Har du bodd i Norge de siste tre årene?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Utenlandsopphold",
-          "verdiliste": [
-            {
-              "label": "Fra",
-              "verdi": "04.12.2012"
-            },
-            {
-              "label": "Til",
-              "verdi": "18.12.2012"
-            },
-            {
-              "label": "I hvilket land oppholdt du deg?",
-              "verdi": "Spania"
-            },
-            {
-              "label": "Hvorfor bodde du i utlandet?",
-              "verdi": "Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Bosituasjonen din",
-      "verdiliste": [
-        {
-          "label": "Deler du bolig med andre voksne?",
-          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label": "Om samboeren din",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        },
-        {
-          "label": "Når flyttet dere sammen?",
-          "verdi": "12.08.2018"
-        }
-      ]
-    },
-    {
-      "label": "Sivilstandsplaner",
-      "verdiliste": [
-        {
-          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når skal dette skje?",
-          "verdi": "15.04.2021"
-        },
-        {
-          "label": "Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Barn",
-      "verdiliste": [
-        {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
-            },
-            {
-              "label": "Erklæring om samlivsbrudd",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Arbeid, utdanning og andre aktiviteter",
-      "verdiliste": [
-        {
-          "label": "Skole/utdanningssted",
-          "verdi": "UiO"
-        },
-        {
-          "label": "Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Profesjonsstudium Informatikk"
-            },
-            {
-              "label": "Når skal du være elev/student?",
-              "verdi": "Fra januar 1999 til oktober 2004"
-            }
-          ]
-        },
-        {
-          "label": "Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Profesjonsstudium Informatikk"
-            },
-            {
-              "label": "Når skal du være elev/student?",
-              "verdi": "Fra 01.01.1999 til 01.10.2004"
-            }
-          ]
-        },
-        {
-          "label": "Er utdanningen offentlig eller privat?",
-          "verdi": "Offentlig"
-        },
-        {
-          "label": "Heltid, eller deltid",
-          "verdi": "Deltid"
-        },
-        {
-          "label": "Hvor mye skal du studere?",
-          "verdi": "300"
-        },
-        {
-          "label": "Hva er målet med utdanningen?",
-          "verdi": "Økonomisk selvstendighet"
-        },
-        {
-          "label": "Har du tatt utdanning etter grunnskolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Tidligere Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Master Fysikk"
-            },
-            {
-              "label": "Når var du elev/student?",
-              "verdi": "Fra januar 1999 til oktober 2004"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Vedlegg",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Utgifter til utdanning"
-        }
-      ]
-    }
-  ],
-  "pdfConfig": {
-    "harInnholdsfortegnelse": true,
-    "språk": "NB"
+  "label" : "Søknad om stønad til skolepenger (NAV 15-00.04)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barn",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Skole/utdanningssted",
+      "verdi" : "UiO"
+    }, {
+      "label" : "Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Profesjonsstudium Informatikk"
+      }, {
+        "label" : "Når skal du være elev/student?",
+        "verdi" : "Fra januar 1999 til oktober 2004"
+      } ]
+    }, {
+      "label" : "Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Profesjonsstudium Informatikk"
+      }, {
+        "label" : "Når skal du være elev/student?",
+        "verdi" : "Fra 01.01.1999 til 01.10.2004"
+      } ]
+    }, {
+      "label" : "Er utdanningen offentlig eller privat?",
+      "verdi" : "Offentlig"
+    }, {
+      "label" : "Heltid, eller deltid",
+      "verdi" : "Deltid"
+    }, {
+      "label" : "Hvor mye skal du studere?",
+      "verdi" : "300"
+    }, {
+      "label" : "Hva er målet med utdanningen?",
+      "verdi" : "Økonomisk selvstendighet"
+    }, {
+      "label" : "Har du tatt utdanning etter grunnskolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Tidligere Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Master Fysikk"
+      }, {
+        "label" : "Når var du elev/student?",
+        "verdi" : "Fra januar 1999 til oktober 2004"
+      } ]
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Utgifter til utdanning"
+    } ]
+  } ],
+  "pdfConfig" : {
+    "harInnholdsfortegnelse" : true,
+    "språk" : "NB"
   }
 }

--- a/src/test/resources/json/pdf_generated_skolepenger.json
+++ b/src/test/resources/json/pdf_generated_skolepenger.json
@@ -1,390 +1,274 @@
 {
-  "label": "Søknad om stønad til skolepenger (NAV 15-00.04)",
-  "verdiliste": [
-    {
-      "label": "detaljer",
-      "verdiliste": [
-        {
-          "label": "mottat",
-          "verdi": "01.01.2020 00:00:00"
-        }
-      ]
-    },
-    {
-      "label": "Søker",
-      "verdiliste": [
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Navn",
-          "verdi": "Kari Nordmann"
-        },
-        {
-          "label": "Statsborgerskap",
-          "verdi": "Norsk"
-        },
-        {
-          "label": "Adresse",
-          "verdi": "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
-        },
-        {
-          "label": "Sivilstand",
-          "verdi": "Ugift"
-        }
-      ]
-    },
-    {
-      "label": "Detaljer om sivilstand",
-      "verdiliste": [
-        {
-          "label": "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "giftIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "separertEllerSkiltIUtlandetDokumentasjon",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når søkte dere eller reiste sak?",
-          "verdi": "23.12.2015"
-        },
-        {
-          "label": "Skilsmisse- eller separasjonsbevilling",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Hva er grunnen til at du er alene med barn?",
-          "verdi": "Endring i samværsordning"
-        },
-        {
-          "label": "Erklæring om samlivsbrudd",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Dato for samlivsbrudd",
-          "verdi": "03.10.2014"
-        },
-        {
-          "label": "Når flyttet dere fra hverandre?",
-          "verdi": "04.10.2014"
-        },
-        {
-          "label": "Når skjedde endringen / når skal endringen skje?",
-          "verdi": "17.04.2013"
-        }
-      ]
-    },
-    {
-      "label": "Opphold i Norge",
-      "verdiliste": [
-        {
-          "label": "Oppholder du deg i Norge?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Har du bodd i Norge de siste tre årene?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Utenlandsopphold",
-          "verdiliste": [
-            {
-              "label": "Fra",
-              "verdi": "04.12.2012"
-            },
-            {
-              "label": "Til",
-              "verdi": "18.12.2012"
-            },
-            {
-              "label" : "I hvilket land oppholdt du deg?",
-              "verdi" : "Spania"
-            },
-            {
-              "label": "Hvorfor bodde du i utlandet?",
-              "verdi": "Granca, Granca, Granca"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Bosituasjonen din",
-      "verdiliste": [
-        {
-          "label": "Deler du bolig med andre voksne?",
-          "verdi": "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
-        },
-        {
-          "label": "Om samboeren din",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        },
-        {
-          "label": "Når flyttet dere sammen?",
-          "verdi": "12.08.2018"
-        }
-      ]
-    },
-    {
-      "label": "Sivilstandsplaner",
-      "verdiliste": [
-        {
-          "label": "Har du konkrete planer om å gifte deg eller bli samboer",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Når skal dette skje?",
-          "verdi": "15.04.2021"
-        },
-        {
-          "label": "Hvem skal du gifte deg eller bli samboer med?",
-          "verdiliste": [
-            {
-              "label": "Navn",
-              "verdi": "Bob Burger"
-            },
-            {
-              "label": "Fødselsdato",
-              "verdi": "18.02.1992"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Barn",
-      "verdiliste": [
-        {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
-          "verdiliste": [
-            {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
-            },
-            {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
-            },
-            {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
-              "verdi": "Ja"
-            },
-            {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
-            },
-            {
-              "label": "Erklæring om samlivsbrudd",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Arbeid, utdanning og andre aktiviteter",
-      "verdiliste": [
-        {
-          "label": "Skole/utdanningssted",
-          "verdi": "UiO"
-        },
-        {
-          "label": "Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Profesjonsstudium Informatikk"
-            },
-            {
-              "label": "Når skal du være elev/student?",
-              "verdi": "Fra januar 1999 til oktober 2004"
-            }
-          ]
-        },
-        {
-          "label": "Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Profesjonsstudium Informatikk"
-            },
-            {
-              "label": "Når skal du være elev/student?",
-              "verdi": "Fra 01.01.1999 til 01.10.2004"
-            }
-          ]
-        },
-        {
-          "label": "Er utdanningen offentlig eller privat?",
-          "verdi": "Offentlig"
-        },
-        {
-          "label": "Heltid, eller deltid",
-          "verdi": "Deltid"
-        },
-        {
-          "label": "Hvor mye skal du studere?",
-          "verdi": "300"
-        },
-        {
-          "label": "Hva er målet med utdanningen?",
-          "verdi": "Økonomisk selvstendighet"
-        },
-        {
-          "label": "Har du tatt utdanning etter grunnskolen?",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Tidligere Utdanning",
-          "verdiliste": [
-            {
-              "label": "Linje/kurs/grad",
-              "verdi": "Master Fysikk"
-            },
-            {
-              "label": "Når var du elev/student?",
-              "verdi": "Fra januar 1999 til oktober 2004"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "label": "Vedlegg",
-      "verdiliste": [
-        {
-          "label": "Vedlegg",
-          "verdi": "Utgifter til utdanning"
-        }
-      ]
-    }
-  ]
+  "label" : "Søknad om stønad til skolepenger (NAV 15-00.04)",
+  "verdiliste" : [ {
+    "label" : "detaljer",
+    "verdiliste" : [ {
+      "label" : "mottat",
+      "verdi" : "01.01.2020 00:00:00"
+    } ]
+  }, {
+    "label" : "Søker",
+    "verdiliste" : [ {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Navn",
+      "verdi" : "Kari Nordmann"
+    }, {
+      "label" : "Statsborgerskap",
+      "verdi" : "Norsk"
+    }, {
+      "label" : "Adresse",
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
+    }, {
+      "label" : "Sivilstand",
+      "verdi" : "Ugift"
+    } ]
+  }, {
+    "label" : "Detaljer om sivilstand",
+    "verdiliste" : [ {
+      "label" : "Er du gift uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "giftIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Er du separert eller skilt uten at dette er formelt registrert eller godkjent i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "separertEllerSkiltIUtlandetDokumentasjon",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Har dere søkt om separasjon, søkt om skilsmisse eller reist sak for domstolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når søkte dere eller reiste sak?",
+      "verdi" : "23.12.2015"
+    }, {
+      "label" : "Skilsmisse- eller separasjonsbevilling",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Hva er grunnen til at du er alene med barn?",
+      "verdi" : "Endring i samværsordning"
+    }, {
+      "label" : "Erklæring om samlivsbrudd",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Dato for samlivsbrudd",
+      "verdi" : "03.10.2014"
+    }, {
+      "label" : "Når flyttet dere fra hverandre?",
+      "verdi" : "04.10.2014"
+    }, {
+      "label" : "Når skjedde endringen / når skal endringen skje?",
+      "verdi" : "17.04.2013"
+    } ]
+  }, {
+    "label" : "Opphold i Norge",
+    "verdiliste" : [ {
+      "label" : "Oppholder du deg i Norge?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Har du bodd i Norge de siste tre årene?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Utenlandsopphold",
+      "verdiliste" : [ {
+        "label" : "Fra",
+        "verdi" : "04.12.2012"
+      }, {
+        "label" : "Til",
+        "verdi" : "18.12.2012"
+      }, {
+        "label" : "I hvilket land oppholdt du deg?",
+        "verdi" : "Spania"
+      }, {
+        "label" : "Hvorfor bodde du i utlandet?",
+        "verdi" : "Granca, Granca, Granca"
+      } ]
+    } ]
+  }, {
+    "label" : "Bosituasjonen din",
+    "verdiliste" : [ {
+      "label" : "Deler du bolig med andre voksne?",
+      "verdi" : "Ja, jeg har samboer og lever i et ekteskapslignende forhold"
+    }, {
+      "label" : "Om samboeren din",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    }, {
+      "label" : "Når flyttet dere sammen?",
+      "verdi" : "12.08.2018"
+    } ]
+  }, {
+    "label" : "Sivilstandsplaner",
+    "verdiliste" : [ {
+      "label" : "Har du konkrete planer om å gifte deg eller bli samboer",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Når skal dette skje?",
+      "verdi" : "15.04.2021"
+    }, {
+      "label" : "Hvem skal du gifte deg eller bli samboer med?",
+      "verdiliste" : [ {
+        "label" : "Navn",
+        "verdi" : "Bob Burger"
+      }, {
+        "label" : "Fødselsdato",
+        "verdi" : "18.02.1992"
+      } ]
+    } ]
+  }, {
+    "label" : "Barn",
+    "verdiliste" : [ {
+      "label" : "Barnets fulle navn, hvis dette er bestemt",
+      "verdi" : "Sorgløs"
+    }, {
+      "label" : "Fødselsnummer",
+      "verdi" : "03125462714"
+    }, {
+      "label" : "Skal ha samme adresse",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Ikke registrert på søkers adresse",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Er barnet født?",
+      "verdi" : "Nei"
+    }, {
+      "label" : "Termindato",
+      "verdi" : "16.05.2020"
+    }, {
+      "label" : "Bekreftelse på ventet fødselsdato",
+      "verdiliste" : [ {
+        "label" : "harSendtInn",
+        "verdi" : "Nei"
+      } ]
+    }, {
+      "label" : "Barnets andre forelder",
+      "verdiliste" : [ {
+        "label" : "Hvorfor kan du ikke oppgi den andre forelderen?",
+        "verdi" : "Fordi jeg ikke liker hen."
+      } ]
+    }, {
+      "label" : "Samvær",
+      "verdiliste" : [ {
+        "label" : "Har den andre forelderen samvær med barnet",
+        "verdi" : "Ja, men ikke mer enn vanlig samværsrett"
+      }, {
+        "label" : "Har dere skriftlig samværsavtale for barnet?",
+        "verdi" : "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+      }, {
+        "label" : "Avtale om samvær",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Skal barnet bo hos deg",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvordan praktiserer dere samværet?",
+        "verdi" : "Litt hver for oss"
+      }, {
+        "label" : "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+        "verdi" : "ja"
+      }, {
+        "label" : "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+        "verdi" : "Ekstra info?"
+      }, {
+        "label" : "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+        "verdi" : "Ja"
+      }, {
+        "label" : "Når flyttet dere fra hverandre?",
+        "verdi" : "21.07.2018"
+      }, {
+        "label" : "Erklæring om samlivsbrudd",
+        "verdiliste" : [ {
+          "label" : "harSendtInn",
+          "verdi" : "Nei"
+        } ]
+      }, {
+        "label" : "Hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi møtes også uten at barnet er til stede"
+      }, {
+        "label" : "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+        "verdi" : "Vi sees stadig vekk"
+      } ]
+    } ]
+  }, {
+    "label" : "Arbeid, utdanning og andre aktiviteter",
+    "verdiliste" : [ {
+      "label" : "Skole/utdanningssted",
+      "verdi" : "UiO"
+    }, {
+      "label" : "Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Profesjonsstudium Informatikk"
+      }, {
+        "label" : "Når skal du være elev/student?",
+        "verdi" : "Fra januar 1999 til oktober 2004"
+      } ]
+    }, {
+      "label" : "Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Profesjonsstudium Informatikk"
+      }, {
+        "label" : "Når skal du være elev/student?",
+        "verdi" : "Fra 01.01.1999 til 01.10.2004"
+      } ]
+    }, {
+      "label" : "Er utdanningen offentlig eller privat?",
+      "verdi" : "Offentlig"
+    }, {
+      "label" : "Heltid, eller deltid",
+      "verdi" : "Deltid"
+    }, {
+      "label" : "Hvor mye skal du studere?",
+      "verdi" : "300"
+    }, {
+      "label" : "Hva er målet med utdanningen?",
+      "verdi" : "Økonomisk selvstendighet"
+    }, {
+      "label" : "Har du tatt utdanning etter grunnskolen?",
+      "verdi" : "Ja"
+    }, {
+      "label" : "Tidligere Utdanning",
+      "verdiliste" : [ {
+        "label" : "Linje/kurs/grad",
+        "verdi" : "Master Fysikk"
+      }, {
+        "label" : "Når var du elev/student?",
+        "verdi" : "Fra januar 1999 til oktober 2004"
+      } ]
+    } ]
+  }, {
+    "label" : "Vedlegg",
+    "verdiliste" : [ {
+      "label" : "Vedlegg",
+      "verdi" : "Utgifter til utdanning"
+    } ]
+  } ]
 }

--- a/src/test/resources/json/pdf_generated_skolepenger_med_typer.json
+++ b/src/test/resources/json/pdf_generated_skolepenger_med_typer.json
@@ -19,7 +19,7 @@
       "verdi" : "Norsk"
     }, {
       "label" : "Adresse",
-      "verdi" : "Jerpefaret 5C\n\n1440 Drøbak\n\nNorge"
+      "verdi" : "Jerpefaret 5C\n1440 Drøbak\nNorge"
     }, {
       "label" : "Sivilstand",
       "verdi" : "Ugift"


### PR DESCRIPTION
Denne PR-en forbedrer funksjonen tilUtskriftsformat som formaterer en adresse til et lesbart utskriftsformat. Endringene sikrer bedre håndtering av tomme eller null verdier og tar vekk unødvendig antall linjeskift 


edit: 
har skilt pdfKvittering fra pdfGen(den gamle flyten)