### PR TITLE
Fiks språk på rett format

### DIFF
--- a/src/test/resources/json/pdf_generated_barnetilsyn_med_typer.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn_med_typer.json
@@ -597,6 +597,6 @@
   ],
   "pdfConfig": {
     "harInnholdsfortegnelse": true,
-    "språk": "NB"
+    "språk": "nb"
   }
 }

--- a/src/test/resources/json/pdf_generated_overgangsstønad_med_typer.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad_med_typer.json
@@ -627,6 +627,6 @@
   ],
   "pdfConfig": {
     "harInnholdsfortegnelse": true,
-    "språk": "NB"
+    "språk": "nb"
   }
 }


### PR DESCRIPTION
Språk skal være med små bokstaver ikke store, så det er likt over alt