### PR TITLE
Barn og arbeidsforhold blir ikke lenger samlet i ett objekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMap.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.mottak.repository.domain.FeltMap
 import no.nav.familie.ef.mottak.repository.domain.PdfConfig
 import no.nav.familie.ef.mottak.repository.domain.VerdilisteElement
 import no.nav.familie.kontrakter.ef.søknad.Adresse
+import no.nav.familie.kontrakter.ef.søknad.Barn
 import no.nav.familie.kontrakter.ef.søknad.Datoperiode
 import no.nav.familie.kontrakter.ef.søknad.Dokumentasjon
 import no.nav.familie.kontrakter.ef.søknad.MånedÅrPeriode
@@ -49,7 +50,11 @@ object SøknadTilFeltMap {
     ): FeltMap {
         val finnFelter = finnFelter(søknad)
         val vedlegg = mapTilVedlegg(vedleggTitler)
-        return FeltMap("Søknad om overgangsstønad (NAV 15-00.01)", finnFelter + vedlegg, PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"))
+        return FeltMap(
+            "Søknad om overgangsstønad (NAV 15-00.01)",
+            finnFelter + vedlegg,
+            PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"),
+        )
     }
 
     fun mapBarnetilsyn(
@@ -58,7 +63,11 @@ object SøknadTilFeltMap {
     ): FeltMap {
         val finnFelter = finnFelter(søknad)
         val vedlegg = mapTilVedlegg(vedleggTitler)
-        return FeltMap("Søknad om stønad til barnetilsyn (NAV 15-00.02)", finnFelter + vedlegg, PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"))
+        return FeltMap(
+            "Søknad om stønad til barnetilsyn (NAV 15-00.02)",
+            finnFelter + vedlegg,
+            PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"),
+        )
     }
 
     fun mapSkolepenger(
@@ -67,12 +76,20 @@ object SøknadTilFeltMap {
     ): FeltMap {
         val finnFelter = finnFelter(søknad)
         val vedlegg = mapTilVedlegg(vedleggTitler)
-        return FeltMap("Søknad om stønad til skolepenger (NAV 15-00.04)", finnFelter + vedlegg, PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"))
+        return FeltMap(
+            "Søknad om stønad til skolepenger (NAV 15-00.04)",
+            finnFelter + vedlegg,
+            PdfConfig(true, søknad.innsendingsdetaljer.verdi.språk ?: "nb"),
+        )
     }
 
     fun mapSkjemafelter(skjema: SkjemaForArbeidssøker): FeltMap {
         val finnFelter = finnFelter(skjema)
-        return FeltMap("Skjema for arbeidssøker - 15-08.01", finnFelter, PdfConfig(false, skjema.innsendingsdetaljer.verdi.språk ?: "nb"))
+        return FeltMap(
+            "Skjema for arbeidssøker - 15-08.01",
+            finnFelter,
+            PdfConfig(false, skjema.innsendingsdetaljer.verdi.språk ?: "nb"),
+        )
     }
 
     fun mapEttersending(
@@ -122,15 +139,14 @@ object SøknadTilFeltMap {
                 return mapDokumentasjon(entitet as Søknadsfelt<Dokumentasjon>)
             }
             if (entitet.verdi!!::class in endNodes) {
-                return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
+                return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) }
+                    ?: emptyList()
             }
             if ((entitet.label == "Barna dine" || entitet.label == "Your children") && entitet.verdi is List<*>) {
-                val elementLabel = if (entitet.label == "Barna dine") "Barn" else "Child"
-                return mapListeElementer(elementLabel, entitet.label, entitet.verdi as List<*>, list)
+                return mapListeElementer(entitet)
             }
             if ((entitet.label == "Om arbeidsforholdet ditt" || entitet.label == "About your employment") && entitet.verdi is List<*>) {
-                val elementLabel = if (entitet.label == "Om arbeidsforholdet ditt") "Arbeidsforhold" else "Employment"
-                return mapListeElementer(elementLabel, entitet.label, entitet.verdi as List<*>, list)
+                return mapListeElementer(entitet)
             }
             if (entitet.alternativer != null) {
                 val verdi =
@@ -138,13 +154,21 @@ object SøknadTilFeltMap {
                         is List<*> -> verdi.joinToString("\n\n") { it.toString() }
                         else -> verdi?.toString() ?: ""
                     }
-                return listOf(VerdilisteElement(entitet.label, visningsVariant = VisningsVariant.PUNKTLISTE.toString(), verdi = verdi, alternativer = entitet.alternativer?.joinToString(" / ")))
+                return listOf(
+                    VerdilisteElement(
+                        entitet.label,
+                        visningsVariant = VisningsVariant.PUNKTLISTE.toString(),
+                        verdi = verdi,
+                        alternativer = entitet.alternativer?.joinToString(" / "),
+                    ),
+                )
             }
             if (entitet.verdi is List<*>) {
                 val verdiliste = entitet.verdi as List<*>
 
                 if (verdiliste.firstOrNull() is String) {
-                    return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) } ?: emptyList()
+                    return FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet)?.let { listOf(it) }
+                        ?: emptyList()
                 }
             }
             // skal ekskluderes
@@ -158,25 +182,58 @@ object SøknadTilFeltMap {
     }
 
     private fun mapDokumentasjon(entitet: Søknadsfelt<Dokumentasjon>): List<VerdilisteElement> {
-        val list = listOf(FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet.verdi.harSendtInnTidligere))
+        val list =
+            listOf(FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(entitet.verdi.harSendtInnTidligere))
         if (list.size == 1 && list.first()?.verdiliste.isNullOrEmpty() && list.first()?.verdi.isNullOrEmpty()) {
             return emptyList()
         }
         return listOf(VerdilisteElement(label = entitet.label, verdiliste = list.filterNotNull()))
     }
 
-    private fun mapListeElementer(
+    private fun mapBarnElementer(
         elementLabel: String,
-        label: String,
-        elementer: List<*>,
-        verdiliste: List<VerdilisteElement>,
+        indeks: Int,
+        barn: Barn,
+    ): VerdilisteElement? {
+        val element = if (elementLabel == "Barna dine") "Barn" else "Child"
+        val tabellCaption = "$element ${indeks + 1}"
+        val verdilisteElementListe = finnFelter(barn).filterNot { it.verdi == "" && it.verdiliste.isNullOrEmpty() }
+        return verdilisteElementListe.takeIf { it.isNotEmpty() }?.let {
+            VerdilisteElement(label = tabellCaption, verdiliste = it)
+        }
+    }
+
+    private fun mapArbeidsforholdElementer(
+        elementLabel: String,
+        indeks: Int,
+        arbeidsforhold: no.nav.familie.kontrakter.ef.søknad.Arbeidsgiver,
+    ): VerdilisteElement? {
+        val element = if (elementLabel == "Om arbeidsforholdet ditt") "Arbeidsforhold" else "Employment"
+        val tabellCaption = "$element ${indeks + 1}"
+        val verdilisteElementListe = finnFelter(arbeidsforhold)
+        return verdilisteElementListe.takeIf { it.isNotEmpty() }?.let {
+            VerdilisteElement(label = tabellCaption, verdiliste = it)
+        }
+    }
+
+    private fun mapListeElementer(
+        entitet: Søknadsfelt<*>,
     ): List<VerdilisteElement> {
-        val ekskluderTommeElementer = verdiliste.filterNot { it.verdi.isNullOrEmpty() && it.verdiliste.isNullOrEmpty() }
         val mappedElementer =
-            elementer.mapIndexedNotNull { indeks, it ->
-                it?.let { VerdilisteElement("$elementLabel ${indeks + 1}", verdiliste = ekskluderTommeElementer) }
+            (entitet.verdi as List<*>).mapIndexedNotNull { indeks, it ->
+                when (it) {
+                    is Barn -> mapBarnElementer(entitet.label, indeks, it)
+                    is no.nav.familie.kontrakter.ef.søknad.Arbeidsgiver -> mapArbeidsforholdElementer(entitet.label, indeks, it)
+                    else -> null
+                }
             }
-        return listOf(VerdilisteElement(label, verdiliste = mappedElementer, visningsVariant = VisningsVariant.TABELL.toString()))
+        return listOf(
+            VerdilisteElement(
+                entitet.label,
+                verdiliste = mappedElementer,
+                visningsVariant = VisningsVariant.TABELL.toString(),
+            ),
+        )
     }
 
     /**

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadTilFeltMapTest.kt
@@ -88,7 +88,7 @@ class SøknadTilFeltMapTest {
 
     @Test
     fun `mapSøknadsfelter printer pdf for å se endringer i pdf-genereringen i PR - overgangsstønad`() {
-        val søknad = Testdata.søknadOvergangsstønad
+        val søknad = Testdata.søknadOvergangsstønadNy
 
         val vedlegg =
             listOf(
@@ -111,7 +111,7 @@ class SøknadTilFeltMapTest {
 
     @Test
     fun `mapSøknadsfelter printer pdf for å se endringer i pdf-genereringen i PR - barnetilsyn`() {
-        val søknad = Testdata.søknadBarnetilsyn
+        val søknad = Testdata.søknadBarnetilsynNy
 
         val vedlegg =
             listOf(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/Testdata.kt
@@ -98,6 +98,21 @@ internal object Testdata {
             Søknadsfelt("Når søker du stønad fra?", stønadsstart()),
         )
 
+    val søknadOvergangsstønadNy =
+        SøknadOvergangsstønad(
+            Søknadsfelt("detaljer", Innsendingsdetaljer(Søknadsfelt("mottat", mottat), mottat.minusDays(1).toLocalDate())),
+            Søknadsfelt("Søker", personalia()),
+            Søknadsfelt("Opplysninger om adresse", adresseopplysninger()),
+            Søknadsfelt("Detaljer om sivilstand", sivilstandsdetaljer()),
+            Søknadsfelt("Opphold i Norge", medlemskapsdetaljer()),
+            Søknadsfelt("Bosituasjonen din", bosituasjon()),
+            Søknadsfelt("Sivilstandsplaner", sivilstandsplaner()),
+            Søknadsfelt("Barna dine", listOf(barn(), barn2())),
+            Søknadsfelt("Arbeid, utdanning og andre aktiviteter", aktivitet()),
+            Søknadsfelt("Mer om situasjonen din", situasjon()),
+            Søknadsfelt("Når søker du stønad fra?", stønadsstart()),
+        )
+
     val søknadOvergangsstønadMedTommeFelter =
         SøknadOvergangsstønad(
             Søknadsfelt("detaljer", Innsendingsdetaljer(Søknadsfelt("mottat", mottat), mottat.minusDays(1).toLocalDate())),
@@ -123,6 +138,27 @@ internal object Testdata {
             Søknadsfelt("Bosituasjonen din", bosituasjon()),
             Søknadsfelt("Sivilstandsplaner", sivilstandsplaner()),
             Søknadsfelt("Barn", listOf(barn(barnetilsyn = true))),
+            Søknadsfelt("Arbeid, utdanning og andre aktiviteter", aktivitet()),
+            Søknadsfelt("Når søker du stønad fra?", stønadsstart()),
+            dokumentasjon =
+                BarnetilsynDokumentasjon(
+                    barnepassordningFaktura = dokumentfelt("Barnepassordning faktura"),
+                    avtaleBarnepasser = dokumentfelt("Avtale barnepasser"),
+                    arbeidstid = dokumentfelt("Arbeidstid"),
+                    spesielleBehov = dokumentfelt("Spesielle behov"),
+                ),
+        )
+
+    val søknadBarnetilsynNy =
+        SøknadBarnetilsyn(
+            Søknadsfelt("detaljer", Innsendingsdetaljer(Søknadsfelt("mottat", mottat), mottat.minusDays(1).toLocalDate())),
+            Søknadsfelt("Søker", personalia()),
+            Søknadsfelt("Opplysninger om adresse", adresseopplysninger()),
+            Søknadsfelt("Detaljer om sivilstand", sivilstandsdetaljer()),
+            Søknadsfelt("Opphold i Norge", medlemskapsdetaljer()),
+            Søknadsfelt("Bosituasjonen din", bosituasjon()),
+            Søknadsfelt("Sivilstandsplaner", sivilstandsplaner()),
+            Søknadsfelt("Barna dine", listOf(barn(barnetilsyn = true))),
             Søknadsfelt("Arbeid, utdanning og andre aktiviteter", aktivitet()),
             Søknadsfelt("Når søker du stønad fra?", stønadsstart()),
             dokumentasjon =
@@ -456,6 +492,84 @@ internal object Testdata {
         Barn(
             navn = Søknadsfelt("Barnets fulle navn, hvis dette er bestemt", "Sorgløs"),
             erBarnetFødt = Søknadsfelt("Er barnet født?", false),
+            fødselTermindato = Søknadsfelt("Termindato", LocalDate.of(2020, 5, 16)),
+            terminbekreftelse = dokumentfelt("Bekreftelse på ventet fødselsdato"),
+            annenForelder =
+                Søknadsfelt(
+                    "Barnets andre forelder",
+                    AnnenForelder(
+                        Søknadsfelt(
+                            "Hvorfor kan du ikke oppgi den andre forelderen?",
+                            "Fordi jeg ikke liker hen.",
+                        ),
+                    ),
+                ),
+            fødselsnummer = Søknadsfelt("Fødselsnummer", Fødselsnummer("03125462714")), // random fnr anno 1854,
+            harSkalHaSammeAdresse = Søknadsfelt("Skal ha samme adresse", true),
+            ikkeRegistrertPåSøkersAdresseBeskrivelse = Søknadsfelt("Ikke registrert på søkers adresse", "Nei"),
+            samvær =
+                Søknadsfelt(
+                    "Samvær",
+                    Samvær(
+                        skalAnnenForelderHaSamvær =
+                            Søknadsfelt(
+                                "Har den andre forelderen samvær med barnet",
+                                "Ja, men ikke mer enn vanlig samværsrett",
+                            ),
+                        harDereSkriftligAvtaleOmSamvær =
+                            Søknadsfelt(
+                                "Har dere skriftlig samværsavtale for barnet?",
+                                "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene",
+                            ),
+                        samværsavtale = dokumentfelt("Avtale om samvær"),
+                        skalBarnetBoHosSøkerMenAnnenForelderSamarbeiderIkke = dokumentfelt("Skal barnet bo hos deg"),
+                        hvordanPraktiseresSamværet =
+                            Søknadsfelt(
+                                "Hvordan praktiserer dere samværet?",
+                                "Litt hver for oss",
+                            ),
+                        borAnnenForelderISammeHus =
+                            Søknadsfelt(
+                                "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+                                "ja",
+                            ),
+                        borAnnenForelderISammeHusBeskrivelse =
+                            Søknadsfelt(
+                                "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+                                "Ekstra info?",
+                            ),
+                        harDereTidligereBoddSammen =
+                            Søknadsfelt(
+                                "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+                                true,
+                            ),
+                        nårFlyttetDereFraHverandre =
+                            Søknadsfelt(
+                                "Når flyttet dere fra hverandre?",
+                                LocalDate.of(2018, 7, 21),
+                            ),
+                        erklæringOmSamlivsbrudd = dokumentfelt("Erklæring om samlivsbrudd"),
+                        hvorMyeErDuSammenMedAnnenForelder =
+                            Søknadsfelt(
+                                "Hvor mye er du sammen med den andre forelderen til barnet?",
+                                "Vi møtes også uten at barnet er til stede",
+                            ),
+                        beskrivSamværUtenBarn =
+                            Søknadsfelt(
+                                "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+                                "Vi sees stadig vekk",
+                            ),
+                    ),
+                ),
+            skalHaBarnepass = if (barnetilsyn) Søknadsfelt("Skal ha barnepass", true) else null,
+            barnepass = if (barnetilsyn) barnepass() else null,
+        )
+
+    @Suppress("LongLine")
+    private fun barn2(barnetilsyn: Boolean = false): Barn =
+        Barn(
+            navn = Søknadsfelt("Navn", "Sorgløs"),
+            erBarnetFødt = Søknadsfelt("Er barnet født?", true),
             fødselTermindato = Søknadsfelt("Termindato", LocalDate.of(2020, 5, 16)),
             terminbekreftelse = dokumentfelt("Bekreftelse på ventet fødselsdato"),
             annenForelder =

--- a/src/test/resources/json/pdf_generated_barnetilsyn_med_typer_ny.json
+++ b/src/test/resources/json/pdf_generated_barnetilsyn_med_typer_ny.json
@@ -217,101 +217,38 @@
       ]
     },
     {
-      "label": "Barn",
+      "label": "Barna dine",
+      "visningsVariant": "TABELL",
       "verdiliste": [
         {
-          "label": "Barnets fulle navn, hvis dette er bestemt",
-          "verdi": "Sorgløs"
-        },
-        {
-          "label": "Fødselsnummer",
-          "verdi": "03125462714"
-        },
-        {
-          "label": "Skal ha samme adresse",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Ikke registrert på søkers adresse",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Er barnet født?",
-          "verdi": "Nei"
-        },
-        {
-          "label": "Termindato",
-          "verdi": "16.05.2020"
-        },
-        {
-          "label": "Bekreftelse på ventet fødselsdato",
+          "label": "Barn 1",
           "verdiliste": [
             {
-              "label": "harSendtInn",
-              "verdi": "Nei"
-            }
-          ]
-        },
-        {
-          "label": "Barnets andre forelder",
-          "verdiliste": [
-            {
-              "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
-              "verdi": "Fordi jeg ikke liker hen."
-            }
-          ]
-        },
-        {
-          "label": "Samvær",
-          "verdiliste": [
-            {
-              "label": "Har den andre forelderen samvær med barnet",
-              "verdi": "Ja, men ikke mer enn vanlig samværsrett"
+              "label": "Barnets fulle navn, hvis dette er bestemt",
+              "verdi": "Sorgløs"
             },
             {
-              "label": "Har dere skriftlig samværsavtale for barnet?",
-              "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+              "label": "Fødselsnummer",
+              "verdi": "03125462714"
             },
             {
-              "label": "Avtale om samvær",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Skal barnet bo hos deg",
-              "verdiliste": [
-                {
-                  "label": "harSendtInn",
-                  "verdi": "Nei"
-                }
-              ]
-            },
-            {
-              "label": "Hvordan praktiserer dere samværet?",
-              "verdi": "Litt hver for oss"
-            },
-            {
-              "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
-              "verdi": "ja"
-            },
-            {
-              "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
-              "verdi": "Ekstra info?"
-            },
-            {
-              "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+              "label": "Skal ha samme adresse",
               "verdi": "Ja"
             },
             {
-              "label": "Når flyttet dere fra hverandre?",
-              "verdi": "21.07.2018"
+              "label": "Ikke registrert på søkers adresse",
+              "verdi": "Nei"
             },
             {
-              "label": "Erklæring om samlivsbrudd",
+              "label": "Er barnet født?",
+              "verdi": "Nei"
+            },
+            {
+              "label": "Termindato",
+              "verdi": "16.05.2020"
+            },
+            {
+              "label": "Bekreftelse på ventet fødselsdato",
               "verdiliste": [
                 {
                   "label": "harSendtInn",
@@ -320,48 +257,117 @@
               ]
             },
             {
-              "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi møtes også uten at barnet er til stede"
-            },
-            {
-              "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
-              "verdi": "Vi sees stadig vekk"
-            }
-          ]
-        },
-        {
-          "label": "Skal ha barnepass",
-          "verdi": "Ja"
-        },
-        {
-          "label": "Barnepass",
-          "verdiliste": [
-            {
-              "label": "Årsak Barnepass",
-              "verdi": "Årsak"
-            },
-            {
-              "label": "Ordninger",
+              "label": "Barnets andre forelder",
               "verdiliste": [
                 {
-                  "label": "Hva slags barnepassordning?",
-                  "verdi": "En"
+                  "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
+                  "verdi": "Fordi jeg ikke liker hen."
+                }
+              ]
+            },
+            {
+              "label": "Samvær",
+              "verdiliste": [
+                {
+                  "label": "Har den andre forelderen samvær med barnet",
+                  "verdi": "Ja, men ikke mer enn vanlig samværsrett"
                 },
                 {
-                  "label": "Navn",
-                  "verdi": "navn"
+                  "label": "Har dere skriftlig samværsavtale for barnet?",
+                  "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
                 },
                 {
-                  "label": "Periode",
-                  "verdi": "Fra januar 2020 til juli 2020"
+                  "label": "Avtale om samvær",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
                 },
                 {
-                  "label": "Periode",
-                  "verdi": "Fra 12.01.2020 til 15.02.2020"
+                  "label": "Skal barnet bo hos deg",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
                 },
                 {
-                  "label": "Beløp",
-                  "verdi": "1000,21"
+                  "label": "Hvordan praktiserer dere samværet?",
+                  "verdi": "Litt hver for oss"
+                },
+                {
+                  "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+                  "verdi": "ja"
+                },
+                {
+                  "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+                  "verdi": "Ekstra info?"
+                },
+                {
+                  "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+                  "verdi": "Ja"
+                },
+                {
+                  "label": "Når flyttet dere fra hverandre?",
+                  "verdi": "21.07.2018"
+                },
+                {
+                  "label": "Erklæring om samlivsbrudd",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
+                },
+                {
+                  "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
+                  "verdi": "Vi møtes også uten at barnet er til stede"
+                },
+                {
+                  "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+                  "verdi": "Vi sees stadig vekk"
+                }
+              ]
+            },
+            {
+              "label": "Skal ha barnepass",
+              "verdi": "Ja"
+            },
+            {
+              "label": "Barnepass",
+              "verdiliste": [
+                {
+                  "label": "Årsak Barnepass",
+                  "verdi": "Årsak"
+                },
+                {
+                  "label": "Ordninger",
+                  "verdiliste": [
+                    {
+                      "label": "Hva slags barnepassordning?",
+                      "verdi": "En"
+                    },
+                    {
+                      "label": "Navn",
+                      "verdi": "navn"
+                    },
+                    {
+                      "label": "Periode",
+                      "verdi": "Fra januar 2020 til juli 2020"
+                    },
+                    {
+                      "label": "Periode",
+                      "verdi": "Fra 12.01.2020 til 15.02.2020"
+                    },
+                    {
+                      "label": "Beløp",
+                      "verdi": "1000,21"
+                    }
+                  ]
                 }
               ]
             }

--- a/src/test/resources/json/pdf_generated_overgangsstønad_med_typer_ny.json
+++ b/src/test/resources/json/pdf_generated_overgangsstønad_med_typer_ny.json
@@ -224,8 +224,8 @@
           "label": "Barn 1",
           "verdiliste": [
             {
-              "label": "Barnets fulle navn, hvis dette er bestemt",
-              "verdi": "Sorgløs"
+                "label": "Barnets fulle navn, hvis dette er bestemt",
+                "verdi": "Sorgløs"
             },
             {
               "label": "Fødselsnummer",
@@ -242,6 +242,121 @@
             {
               "label": "Er barnet født?",
               "verdi": "Nei"
+            },
+            {
+              "label": "Termindato",
+              "verdi": "16.05.2020"
+            },
+            {
+              "label": "Bekreftelse på ventet fødselsdato",
+              "verdiliste": [
+                {
+                  "label": "harSendtInn",
+                  "verdi": "Nei"
+                }
+              ]
+            },
+            {
+              "label": "Barnets andre forelder",
+              "verdiliste": [
+                {
+                  "label": "Hvorfor kan du ikke oppgi den andre forelderen?",
+                  "verdi": "Fordi jeg ikke liker hen."
+                }
+              ]
+            },
+            {
+              "label": "Samvær",
+              "verdiliste": [
+                {
+                  "label": "Har den andre forelderen samvær med barnet",
+                  "verdi": "Ja, men ikke mer enn vanlig samværsrett"
+                },
+                {
+                  "label": "Har dere skriftlig samværsavtale for barnet?",
+                  "verdi": "Ja, men den beskriver ikke når barnet er sammen med hver av foreldrene"
+                },
+                {
+                  "label": "Avtale om samvær",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
+                },
+                {
+                  "label": "Skal barnet bo hos deg",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
+                },
+                {
+                  "label": "Hvordan praktiserer dere samværet?",
+                  "verdi": "Litt hver for oss"
+                },
+                {
+                  "label": "Bor du og den andre forelderen til [barnets navn] i samme hus/blokk, gårdstun, kvartal eller vei?",
+                  "verdi": "ja"
+                },
+                {
+                  "label": "Bor du og den andre forelderen til  i samme hus/blokk beskrivelse",
+                  "verdi": "Ekstra info?"
+                },
+                {
+                  "label": "Har du bodd sammen med den andre forelderen til [barnets fornavn] før?",
+                  "verdi": "Ja"
+                },
+                {
+                  "label": "Når flyttet dere fra hverandre?",
+                  "verdi": "21.07.2018"
+                },
+                {
+                  "label": "Erklæring om samlivsbrudd",
+                  "verdiliste": [
+                    {
+                      "label": "harSendtInn",
+                      "verdi": "Nei"
+                    }
+                  ]
+                },
+                {
+                  "label": "Hvor mye er du sammen med den andre forelderen til barnet?",
+                  "verdi": "Vi møtes også uten at barnet er til stede"
+                },
+                {
+                  "label": "Beskriv  hvor mye er du sammen med den andre forelderen til barnet?",
+                  "verdi": "Vi sees stadig vekk"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Barn 2",
+          "verdiliste": [
+            {
+              "label": "Navn",
+              "verdi": "Sorgløs"
+            },
+            {
+              "label": "Fødselsnummer",
+              "verdi": "03125462714"
+            },
+            {
+              "label": "Skal ha samme adresse",
+              "verdi": "Ja"
+            },
+            {
+              "label": "Ikke registrert på søkers adresse",
+              "verdi": "Nei"
+            },
+            {
+              "label": "Er barnet født?",
+              "verdi": "Ja"
             },
             {
               "label": "Termindato",


### PR DESCRIPTION
Feilen var at objektene ble til ett objekt før og ble plassert i flere objekter slik at barn 1 og barn 2 var i både barn 1 og barn 2.

Nå er dette adskilt og fungerer som tiltenkt igjen.

Både barn og arbeidsforhold testet:
[Test-barn-og-arbeidsforhold.pdf](https://github.com/user-attachments/files/18532087/Test-barn-og-arbeidsforhold.pdf)