### PR TITLE
Brukervarsel migrering for nytt kafka topic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <felles.version>3.20250106100611_6ae49d2</felles.version>
         <prosessering.version>2.20250114104710_d9ad759</prosessering.version>
         <confluent.version>7.8.0</confluent.version>
-        <brukernotifikasjon-skjemas.version>2.6.0</brukernotifikasjon-skjemas.version>
         <kontrakter.version>3.0_20250116111901_78b5a16</kontrakter.version>
         <token-validation.version>5.0.14</token-validation.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
@@ -138,11 +137,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.tms</groupId>
-            <artifactId>brukernotifikasjon-schemas</artifactId>
-            <version>${brukernotifikasjon-skjemas.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
         <sonar.organization>navit</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <brukervarsel-builder.version>2.1.1</brukervarsel-builder.version>
         <!--suppress UnresolvedMavenProperty Ligger som secret i github-->
         <sonar.login>${SONAR_LOGIN}</sonar.login>
     </properties>
@@ -197,6 +198,11 @@
             <groupId>no.nav.familie</groupId>
             <artifactId>prosessering-core</artifactId>
             <version>${prosessering.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.tms.varsel</groupId>
+            <artifactId>kotlin-builder</artifactId>
+            <version>${brukervarsel-builder.version}</version>
         </dependency>
 
         <!-- Database -->

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -66,32 +66,35 @@ class DittNavKafkaProducer(
         melding: String,
         link: String? = null,
         aktivFremTil: ZonedDateTime? = null,
-        eksternKanal: EksternKanal? = null
+        eksternKanal: EksternKanal? = null,
     ) {
-        val varsel = VarselActionBuilder.opprett {
-            this.ident = personIdent
-            this.varselId = varselId
-            this.link = link
-            this.aktivFremTil = aktivFremTil
-            this.type = Varseltype.Beskjed
-            this.sensitivitet = Sensitivitet.High
+        val varsel =
+            VarselActionBuilder.opprett {
+                this.ident = personIdent
+                this.varselId = varselId
+                this.link = link
+                this.aktivFremTil = aktivFremTil
+                this.type = Varseltype.Beskjed
+                this.sensitivitet = Sensitivitet.High
 
-            this.tekst = Tekst(
-                spraakkode = "nb",
-                tekst = melding,
-                default = true
-            )
+                this.tekst =
+                    Tekst(
+                        spraakkode = "nb",
+                        tekst = melding,
+                        default = true,
+                    )
 
-            this.eksternVarsling {
-                this.preferertKanal = eksternKanal
+                this.eksternVarsling {
+                    this.preferertKanal = eksternKanal
+                }
+
+                this.produsent =
+                    Produsent(
+                        cluster = cluster,
+                        namespace = namespace,
+                        appnavn = applicationName,
+                    )
             }
-
-            this.produsent = Produsent(
-                cluster = cluster,
-                namespace = namespace,
-                appnavn = applicationName,
-            )
-        }
 
         secureLogger.debug("Sending to Kafka topic: {}: {}", nyTopic, varsel)
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -61,7 +61,7 @@ class DittNavKafkaProducer(
                     )
             }
 
-        secureLogger.debug("Sending to Kafka topic: {}: {}", topic, varsel)
+        secureLogger.info("Sender til Kafka topic: {}: {}", topic, varsel)
 
         runCatching {
             val producerRecord = ProducerRecord(topic, varselId, varsel)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -5,6 +5,12 @@ import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
 import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.tms.varsel.action.EksternKanal
+import no.nav.tms.varsel.action.Produsent
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Tekst
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -13,70 +19,71 @@ import org.springframework.stereotype.Service
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime
 
 @Service
 class DittNavKafkaProducer(
-    private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${BRUKERNOTIFIKASJON_VARSEL_TOPIC}")
+    val topic: String,
+    @Value("\${NAIS_APP_NAME}")
+    val applicationName: String,
+    @Value("\${NAIS_NAMESPACE}")
+    val namespace: String,
+    @Value("\${NAIS_CLUSTER_NAME}")
+    val cluster: String,
 ) {
-    @Value("\${KAFKA_TOPIC_DITTNAV}")
-    private lateinit var topic: String
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-    fun sendToKafka(
-        fnr: String,
+    fun sendBeskjedTilBruker(
+        type: Varseltype,
+        varselId: String,
+        ident: String,
         melding: String,
-        grupperingsnummer: String,
-        eventId: String,
-        link: URL? = null,
-        kanal: PreferertKanal? = null,
+        sensitivitet: Sensitivitet,
+        link: String? = null,
+        aktivFremTil: ZonedDateTime? = null,
+        smsVarslingstekst: String? = null,
     ) {
-        val nokkel = lagNøkkel(fnr, grupperingsnummer, eventId)
-        val beskjed = lagBeskjed(melding, link, kanal)
+        val varsel = VarselActionBuilder.opprett {
+            this.ident = ident
+            this.type = type
+            this.varselId = varselId
+            this.sensitivitet = sensitivitet
+            this.link = link
+            this.aktivFremTil = aktivFremTil
 
-        secureLogger.debug("Sending to Kafka topic: {}: {}", topic, beskjed)
+            tekst = Tekst(
+                spraakkode = "nb",
+                tekst = melding,
+                default = true
+            )
+
+            eksternVarsling {
+                if (!smsVarslingstekst.isNullOrBlank()) {
+                    preferertKanal = EksternKanal.SMS
+                    this.smsVarslingstekst = smsVarslingstekst
+                }
+            }
+
+            produsent = Produsent(
+                cluster = cluster,
+                namespace = namespace,
+                appnavn = applicationName,
+            )
+        }
+
+        secureLogger.debug("Sending to Kafka topic: {}: {}", topic, varsel)
+
         runCatching {
-            val producerRecord = ProducerRecord(topic, nokkel, beskjed)
+            val producerRecord = ProducerRecord(topic, varselId, varsel)
             kafkaTemplate.send(producerRecord).get()
         }.onFailure {
-            val errorMessage = "Could not send DittNav to Kafka. Check secure logs for more information."
+            val errorMessage = "Could not send varsel to Kafka. Check secure logs for more information."
             logger.error(errorMessage)
-            secureLogger.error("Could not send DittNav to Kafka melding={}", beskjed, it)
+            secureLogger.error("Could not send varsel to Kafka varsel={}", varsel, it)
             throw RuntimeException(errorMessage)
         }
-    }
-
-    private fun lagNøkkel(
-        fnr: String,
-        grupperingsId: String,
-        eventId: String,
-    ): NokkelInput =
-        NokkelInputBuilder()
-            .withAppnavn("familie-ef-mottak")
-            .withNamespace("teamfamilie")
-            .withFodselsnummer(fnr)
-            .withGrupperingsId(grupperingsId)
-            .withEventId(eventId)
-            .build()
-
-    private fun lagBeskjed(
-        melding: String,
-        link: URL?,
-        kanal: PreferertKanal?,
-    ): BeskjedInput {
-        val builder =
-            BeskjedInputBuilder()
-                .withSikkerhetsnivaa(4)
-                .withSynligFremTil(null)
-                .withTekst(melding)
-                .withTidspunkt(LocalDateTime.now(UTC))
-
-        if (link != null) builder.withLink(link)
-        if (kanal != null) builder.withEksternVarsling(true).withPrefererteKanaler(kanal)
-
-        return builder.build()
-    }
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(this::class.java)
-        private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -20,6 +20,7 @@ import java.net.URL
 import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
+import java.util.UUID
 
 @Service
 class DittNavKafkaProducer(
@@ -37,37 +38,32 @@ class DittNavKafkaProducer(
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun sendBeskjedTilBruker(
-        type: Varseltype,
+        personIdent: String,
         varselId: String,
-        ident: String,
         melding: String,
-        sensitivitet: Sensitivitet,
         link: String? = null,
         aktivFremTil: ZonedDateTime? = null,
-        smsVarslingstekst: String? = null,
+        eksternKanal: EksternKanal? = null
     ) {
         val varsel = VarselActionBuilder.opprett {
-            this.ident = ident
-            this.type = type
+            this.ident = personIdent
             this.varselId = varselId
-            this.sensitivitet = sensitivitet
             this.link = link
             this.aktivFremTil = aktivFremTil
+            this.type = Varseltype.Beskjed
+            this.sensitivitet = Sensitivitet.High
 
-            tekst = Tekst(
+            this.tekst = Tekst(
                 spraakkode = "nb",
                 tekst = melding,
                 default = true
             )
 
-            eksternVarsling {
-                if (!smsVarslingstekst.isNullOrBlank()) {
-                    preferertKanal = EksternKanal.SMS
-                    this.smsVarslingstekst = smsVarslingstekst
-                }
+            this.eksternVarsling {
+                this.preferertKanal = eksternKanal
             }
 
-            produsent = Produsent(
+            this.produsent = Produsent(
                 cluster = cluster,
                 namespace = namespace,
                 appnavn = applicationName,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -17,7 +17,7 @@ import java.time.ZonedDateTime
 class DittNavKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     @Value("\${BRUKERNOTIFIKASJON_VARSEL_TOPIC}")
-    val nyTopic: String,
+    val topic: String,
     @Value("\${NAIS_APP_NAME}")
     val applicationName: String,
     @Value("\${NAIS_NAMESPACE}")
@@ -61,10 +61,10 @@ class DittNavKafkaProducer(
                     )
             }
 
-        secureLogger.debug("Sending to Kafka topic: {}: {}", nyTopic, varsel)
+        secureLogger.debug("Sending to Kafka topic: {}: {}", topic, varsel)
 
         runCatching {
-            val producerRecord = ProducerRecord(nyTopic, varselId, varsel)
+            val producerRecord = ProducerRecord(topic, varselId, varsel)
             kafkaTemplate.send(producerRecord).get()
         }.onFailure {
             val errorMessage = "Could not send varsel to Kafka. Check secure logs for more information."

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/DittNavKafkaProducer.kt
@@ -1,10 +1,5 @@
 package no.nav.familie.ef.mottak.service
 
-import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
-import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
-import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.Produsent
 import no.nav.tms.varsel.action.Sensitivitet
@@ -16,15 +11,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
-import java.net.URL
-import java.time.LocalDateTime
-import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
 
 @Service
 class DittNavKafkaProducer(
-    private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
-    private val nyKafkaTemplate: KafkaTemplate<String, String>,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
     @Value("\${BRUKERNOTIFIKASJON_VARSEL_TOPIC}")
     val nyTopic: String,
     @Value("\${NAIS_APP_NAME}")
@@ -34,32 +25,6 @@ class DittNavKafkaProducer(
     @Value("\${NAIS_CLUSTER_NAME}")
     val cluster: String,
 ) {
-    @Value("\${KAFKA_TOPIC_DITTNAV}")
-    private lateinit var topic: String
-
-    fun sendToKafka(
-        fnr: String,
-        melding: String,
-        grupperingsnummer: String,
-        eventId: String,
-        link: URL? = null,
-        kanal: PreferertKanal? = null,
-    ) {
-        val nokkel = lagNøkkel(fnr, grupperingsnummer, eventId)
-        val beskjed = lagBeskjed(melding, link, kanal)
-
-        secureLogger.debug("Sending to Kafka topic: {}: {}", topic, beskjed)
-        runCatching {
-            val producerRecord = ProducerRecord(topic, nokkel, beskjed)
-            kafkaTemplate.send(producerRecord).get()
-        }.onFailure {
-            val errorMessage = "Could not send DittNav to Kafka. Check secure logs for more information."
-            logger.error(errorMessage)
-            secureLogger.error("Could not send DittNav to Kafka melding={}", beskjed, it)
-            throw RuntimeException(errorMessage)
-        }
-    }
-
     fun sendBeskjedTilBruker(
         personIdent: String,
         varselId: String,
@@ -100,44 +65,13 @@ class DittNavKafkaProducer(
 
         runCatching {
             val producerRecord = ProducerRecord(nyTopic, varselId, varsel)
-            nyKafkaTemplate.send(producerRecord).get()
+            kafkaTemplate.send(producerRecord).get()
         }.onFailure {
             val errorMessage = "Could not send varsel to Kafka. Check secure logs for more information."
             logger.error(errorMessage)
             secureLogger.error("Could not send varsel to Kafka varsel={}", varsel, it)
             throw RuntimeException(errorMessage)
         }
-    }
-
-    private fun lagNøkkel(
-        fnr: String,
-        grupperingsId: String,
-        eventId: String,
-    ): NokkelInput =
-        NokkelInputBuilder()
-            .withAppnavn("familie-ef-mottak")
-            .withNamespace("teamfamilie")
-            .withFodselsnummer(fnr)
-            .withGrupperingsId(grupperingsId)
-            .withEventId(eventId)
-            .build()
-
-    private fun lagBeskjed(
-        melding: String,
-        link: URL?,
-        kanal: PreferertKanal?,
-    ): BeskjedInput {
-        val builder =
-            BeskjedInputBuilder()
-                .withSikkerhetsnivaa(4)
-                .withSynligFremTil(null)
-                .withTekst(melding)
-                .withTidspunkt(LocalDateTime.now(UTC))
-
-        if (link != null) builder.withLink(link)
-        if (kanal != null) builder.withEksternVarsling(true).withPrefererteKanaler(kanal)
-
-        return builder.build()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -14,6 +14,8 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -46,13 +48,15 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
 
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
-            producer.sendToKafka(
-                søknad.fnr,
-                linkMelding.melding,
-                task.payload,
-                task.metadata["eventId"].toString(),
-                linkMelding.link,
+            producer.sendBeskjedTilBruker(
+                type = Varseltype.Beskjed,
+                varselId = task.metadata["eventId"].toString(),
+                ident = søknad.fnr,
+                melding = linkMelding.melding,
+                sensitivitet = Sensitivitet.High,
+                link = linkMelding.link.toString()
             )
+
             logger.info("Send melding til ditt nav søknadId=${task.payload}")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -49,11 +49,9 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
             producer.sendBeskjedTilBruker(
-                type = Varseltype.Beskjed,
+                personIdent = søknad.fnr,
                 varselId = task.metadata["eventId"].toString(),
-                ident = søknad.fnr,
                 melding = linkMelding.melding,
-                sensitivitet = Sensitivitet.High,
                 link = linkMelding.link.toString()
             )
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -46,6 +46,7 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
 
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
+            // TODO: Husk å fjerne meg, samt tilsvarende avhengigheter.
             producer.sendToKafka(
                 fnr = søknad.fnr,
                 melding = linkMelding.melding,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -14,8 +14,6 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tms.varsel.action.Sensitivitet
-import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -48,13 +46,13 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
 
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
-            producer.sendBeskjedTilBruker(
-                personIdent = søknad.fnr,
-                varselId = task.metadata["eventId"].toString(),
-                melding = linkMelding.melding,
-                link = linkMelding.link.toString()
+            producer.sendToKafka(
+                søknad.fnr,
+                linkMelding.melding,
+                task.payload,
+                task.metadata["eventId"].toString(),
+                linkMelding.link,
             )
-
             logger.info("Send melding til ditt nav søknadId=${task.payload}")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -47,12 +47,20 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
             producer.sendToKafka(
-                søknad.fnr,
-                linkMelding.melding,
-                task.payload,
-                task.metadata["eventId"].toString(),
-                linkMelding.link,
+                fnr = søknad.fnr,
+                melding = linkMelding.melding,
+                grupperingsnummer = task.payload,
+                eventId = task.metadata["eventId"].toString(),
+                link = linkMelding.link,
             )
+
+            producer.sendBeskjedTilBruker(
+                personIdent = søknad.fnr,
+                varselId = task.metadata["eventId"].toString(),
+                melding = linkMelding.melding,
+                link = linkMelding.link.toString(),
+            )
+
             logger.info("Send melding til ditt nav søknadId=${task.payload}")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -46,15 +46,6 @@ class SendDokumentasjonsbehovMeldingTilDittNavTask(
 
             val linkMelding = lagLinkMelding(søknad, manglerVedleggPåSøknad)
 
-            // TODO: Husk å fjerne meg, samt tilsvarende avhengigheter.
-            producer.sendToKafka(
-                fnr = søknad.fnr,
-                melding = linkMelding.melding,
-                grupperingsnummer = task.payload,
-                eventId = task.metadata["eventId"].toString(),
-                link = linkMelding.link,
-            )
-
             producer.sendBeskjedTilBruker(
                 personIdent = søknad.fnr,
                 varselId = task.metadata["eventId"].toString(),

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -22,6 +22,7 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.util.VirkedagerProvider
+import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
@@ -67,13 +68,11 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         val linkMelding = lagLinkMelding(søknad)
 
         producer.sendBeskjedTilBruker(
-            type = Varseltype.Beskjed,
+            personIdent = søknad.fnr,
             varselId = task.metadata["eventId"].toString(),
-            ident = søknad.fnr,
             melding = linkMelding.melding,
-            sensitivitet = Sensitivitet.High,
             link = linkMelding.link.toString(),
-            smsVarslingstekst = linkMelding.melding + linkMelding.link // TODO: Kanskje endres på litt senere.
+            eksternKanal = EksternKanal.SMS
         )
 
         dokumentasjonsbehovVarslingerSendt.increment()
@@ -97,7 +96,7 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         loggMicrometer(brukerHarSendtInnNoe, tilhørendeBehandleSakOppgaveErPåbegynt)
 
         return brukerHarSendtInnNoe ||
-            tilhørendeBehandleSakOppgaveErPåbegynt
+                tilhørendeBehandleSakOppgaveErPåbegynt
     }
 
     private fun loggMicrometer(

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -22,6 +22,8 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.util.VirkedagerProvider
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -63,14 +65,17 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         }
 
         val linkMelding = lagLinkMelding(søknad)
-        producer.sendToKafka(
-            søknad.fnr,
-            linkMelding.melding,
-            task.payload,
-            task.metadata["eventId"].toString(),
-            linkMelding.link,
-            PreferertKanal.SMS,
+
+        producer.sendBeskjedTilBruker(
+            type = Varseltype.Beskjed,
+            varselId = task.metadata["eventId"].toString(),
+            ident = søknad.fnr,
+            melding = linkMelding.melding,
+            sensitivitet = Sensitivitet.High,
+            link = linkMelding.link.toString(),
+            smsVarslingstekst = linkMelding.melding + linkMelding.link // TODO: Kanskje endres på litt senere.
         )
+
         dokumentasjonsbehovVarslingerSendt.increment()
         logger.info("Sender påminnelse til ditt nav om å sende inn ettersending søknadId=${task.payload}")
     }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.mottak.task
 
 import io.micrometer.core.instrument.Metrics.counter
-import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.repository.domain.Ettersending
@@ -22,6 +21,7 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.util.VirkedagerProvider
+import no.nav.tms.varsel.action.EksternKanal
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -63,13 +63,13 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         }
 
         val linkMelding = lagLinkMelding(søknad)
-        producer.sendToKafka(
-            søknad.fnr,
-            linkMelding.melding,
-            task.payload,
-            task.metadata["eventId"].toString(),
-            linkMelding.link,
-            PreferertKanal.SMS,
+
+        producer.sendBeskjedTilBruker(
+            personIdent = søknad.fnr,
+            varselId = task.metadata["eventId"].toString(),
+            melding = linkMelding.melding,
+            link = linkMelding.link.toString(),
+            eksternKanal = EksternKanal.SMS,
         )
         dokumentasjonsbehovVarslingerSendt.increment()
         logger.info("Sender påminnelse til ditt nav om å sende inn ettersending søknadId=${task.payload}")

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -27,11 +27,9 @@ class SendSøknadMottattTilDittNavTask(
         val søknad = søknadskvitteringService.hentSøknad(task.payload)
 
         producer.sendBeskjedTilBruker(
-            type = Varseltype.Beskjed,
+            personIdent = søknad.fnr,
             varselId = task.metadata["eventId"].toString(),
-            ident = søknad.fnr,
             melding = lagLinkMelding(søknad.dokumenttype),
-            sensitivitet = Sensitivitet.High
         )
 
         logger.info("Send melding til ditt nav søknadId=${task.payload}")

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -7,6 +7,8 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -23,12 +25,15 @@ class SendSøknadMottattTilDittNavTask(
 
     override fun doTask(task: Task) {
         val søknad = søknadskvitteringService.hentSøknad(task.payload)
-        producer.sendToKafka(
-            søknad.fnr,
-            lagLinkMelding(søknad.dokumenttype),
-            task.payload,
-            task.metadata["eventId"].toString(),
+
+        producer.sendBeskjedTilBruker(
+            type = Varseltype.Beskjed,
+            varselId = task.metadata["eventId"].toString(),
+            ident = søknad.fnr,
+            melding = lagLinkMelding(søknad.dokumenttype),
+            sensitivitet = Sensitivitet.High
         )
+
         logger.info("Send melding til ditt nav søknadId=${task.payload}")
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -7,8 +7,6 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import no.nav.tms.varsel.action.Sensitivitet
-import no.nav.tms.varsel.action.Varseltype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -25,13 +23,12 @@ class SendSøknadMottattTilDittNavTask(
 
     override fun doTask(task: Task) {
         val søknad = søknadskvitteringService.hentSøknad(task.payload)
-
-        producer.sendBeskjedTilBruker(
-            personIdent = søknad.fnr,
-            varselId = task.metadata["eventId"].toString(),
-            melding = lagLinkMelding(søknad.dokumenttype),
+        producer.sendToKafka(
+            søknad.fnr,
+            lagLinkMelding(søknad.dokumenttype),
+            task.payload,
+            task.metadata["eventId"].toString(),
         )
-
         logger.info("Send melding til ditt nav søknadId=${task.payload}")
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -23,12 +23,13 @@ class SendSøknadMottattTilDittNavTask(
 
     override fun doTask(task: Task) {
         val søknad = søknadskvitteringService.hentSøknad(task.payload)
-        producer.sendToKafka(
-            søknad.fnr,
-            lagLinkMelding(søknad.dokumenttype),
-            task.payload,
-            task.metadata["eventId"].toString(),
+
+        producer.sendBeskjedTilBruker(
+            personIdent = søknad.fnr,
+            varselId = task.metadata["eventId"].toString(),
+            melding = lagLinkMelding(søknad.dokumenttype),
         )
+
         logger.info("Send melding til ditt nav søknadId=${task.payload}")
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,7 +102,7 @@ database:
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering
 EF_SAK_URL: http://familie-ef-sak
 
-KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
+BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 #STS_URL: http://security-token-service.default.svc.nais.local
 ettersending.ettersendingUrl: https://www.nav.no/familie/alene-med-barn/ettersending
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,9 +100,9 @@ database:
     key: ${DATABASEKEY}
 
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering
-EF_SAK_URL: http://familie-ef-sak
-
 BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
+
+EF_SAK_URL: http://familie-ef-sak
 #STS_URL: http://security-token-service.default.svc.nais.local
 ettersending.ettersendingUrl: https://www.nav.no/familie/alene-med-barn/ettersending
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,6 @@ spring:
           password: ${KAFKA_CREDSTORE_PASSWORD}
     producer:
       acks: all
-      key-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
-      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
   flyway:
     enabled: true
     baseline-version: 6

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,7 +103,6 @@ JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoe
 EF_SAK_URL: http://familie-ef-sak
 
 BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
-KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
 #STS_URL: http://security-token-service.default.svc.nais.local
 ettersending.ettersendingUrl: https://www.nav.no/familie/alene-med-barn/ettersending
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,6 +103,7 @@ JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoe
 EF_SAK_URL: http://familie-ef-sak
 
 BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
+KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
 #STS_URL: http://security-token-service.default.svc.nais.local
 ettersending.ettersendingUrl: https://www.nav.no/familie/alene-med-barn/ettersending
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
@@ -65,8 +65,7 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknad(any())
                 søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any())
                 taskService.save(any())
-                // TODO: Fjern denne.
-                // dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = any(), grupperingsnummer = any(), eventId = EVENT_ID, link = isNull(true))
+
                 dittNavKafkaProducer.sendBeskjedTilBruker(
                     personIdent = FNR,
                     varselId = EVENT_ID,
@@ -157,8 +156,6 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
         sendDokumentasjonsbehovMeldingTilDittNavTask.doTask(Task("", SØKNAD_ID, properties))
 
         verify(exactly = 1) {
-            // TODO: Fjern denne.
-            // dittNavKafkaProducer.sendToKafka(fnr = eq(FNR), melding = eq(forventetMelding), grupperingsnummer = any(), eventId = eq(EVENT_ID), link = link ?: any())
             dittNavKafkaProducer.sendBeskjedTilBruker(
                 personIdent = eq(FNR),
                 varselId = eq(EVENT_ID),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
@@ -65,7 +65,14 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknad(any())
                 søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any())
                 taskService.save(any())
-                dittNavKafkaProducer.sendToKafka(FNR, any(), any(), EVENT_ID, isNull(true))
+                // TODO: Fjern denne.
+                // dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = any(), grupperingsnummer = any(), eventId = EVENT_ID, link = isNull(true))
+                dittNavKafkaProducer.sendBeskjedTilBruker(
+                    personIdent = FNR,
+                    varselId = EVENT_ID,
+                    melding = any(),
+                    link = isNull(true),
+                )
             }
         }
 
@@ -98,7 +105,7 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
             testOgVerifiserMelding(
                 listOf(Dokumentasjonsbehov("", "", false, emptyList())),
                 "Det ser ut til at det mangler noen vedlegg til søknaden din om overgangsstønad. " +
-                        "Se hva som mangler og last opp vedlegg.",
+                    "Se hva som mangler og last opp vedlegg.",
             )
             verify(exactly = 1) {
                 taskService.save(any())
@@ -150,7 +157,14 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
         sendDokumentasjonsbehovMeldingTilDittNavTask.doTask(Task("", SØKNAD_ID, properties))
 
         verify(exactly = 1) {
-            dittNavKafkaProducer.sendToKafka(eq(FNR), eq(forventetMelding), any(), eq(EVENT_ID), link ?: any())
+            // TODO: Fjern denne.
+            // dittNavKafkaProducer.sendToKafka(fnr = eq(FNR), melding = eq(forventetMelding), grupperingsnummer = any(), eventId = eq(EVENT_ID), link = link ?: any())
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                personIdent = eq(FNR),
+                varselId = eq(EVENT_ID),
+                melding = eq(forventetMelding),
+                link = link?.toString() ?: any(),
+            )
         }
     }
 
@@ -163,17 +177,17 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
         }
 
         every { søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any()) } returns
-                DokumentasjonsbehovDto(dokumentasjonsbehov, LocalDateTime.now(), søknadType, FNR)
+            DokumentasjonsbehovDto(dokumentasjonsbehov, LocalDateTime.now(), søknadType, FNR)
     }
 
     private fun mockSøknad(søknadType: SøknadType = SøknadType.OVERGANGSSTØNAD) {
         every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
-                Søknad(
-                    id = SØKNAD_ID,
-                    søknadJson = EncryptedString(""),
-                    dokumenttype = søknadType.dokumentType,
-                    fnr = FNR,
-                )
+            Søknad(
+                id = SØKNAD_ID,
+                søknadJson = EncryptedString(""),
+                dokumenttype = søknadType.dokumentType,
+                fnr = FNR,
+            )
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -220,24 +220,24 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
 
     private fun mockHentSøknad(søknadData: SøknadData) {
         every { søknadskvitteringService.hentSøknad(søknadIds.first()) } returns
-                søknad(
-                    søknadData.id,
-                    søknadData.dokumentType,
-                    søknadData.opprettetTid,
-                )
+            søknad(
+                søknadData.id,
+                søknadData.dokumentType,
+                søknadData.opprettetTid,
+            )
     }
 
     private fun mockHentSøknaderForPerson(søknadData: List<SøknadData>) {
         every { søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
-                listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
-                søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
+            listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
+            søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
     }
 
     private fun ettersending(opprettetTid: LocalDateTime) = Ettersending(ettersendingJson = EncryptedString(""), stønadType = "OS", fnr = FNR, opprettetTid = opprettetTid)
 
     private fun mockHentEttersendingerForPerson(opprettetTid: LocalDateTime? = null) {
         every { ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR)) } returns
-                if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
+            if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
     }
 
     data class SøknadData(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -19,6 +19,8 @@ import no.nav.familie.ef.mottak.util.lagMeldingPåminnelseManglerDokumentasjonsb
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.prosessering.domene.Task
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Varseltype
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.net.URL
@@ -74,7 +76,14 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadskvitteringService.hentSøknad(any())
             søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                type = Varseltype.Beskjed,
+                varselId = EVENT_ID,
+                ident = FNR,
+                melding = eq(forventetMelding.melding),
+                sensitivitet = Sensitivitet.High,
+                smsVarslingstekst = "Test tekst!"
+            )
         }
     }
 
@@ -138,7 +147,15 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadskvitteringService.hentSøknad(any())
             søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                type = Varseltype.Beskjed,
+                varselId = EVENT_ID,
+                ident = FNR,
+                melding = eq(forventetMelding.melding),
+                sensitivitet = Sensitivitet.High,
+                link = forventetMelding.link.toString(),
+                smsVarslingstekst = "Test tekst!"
+            )
         }
     }
 
@@ -162,7 +179,14 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
             søknadskvitteringService.hentSøknad(any())
             søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-            dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                type = Varseltype.Beskjed,
+                varselId = EVENT_ID,
+                ident = FNR,
+                melding = forventetMelding.link.toString(),
+                sensitivitet = any(),
+                smsVarslingstekst = "Test tekst!"
+            )
         }
     }
 
@@ -216,24 +240,24 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
 
     private fun mockHentSøknad(søknadData: SøknadData) {
         every { søknadskvitteringService.hentSøknad(søknadIds.first()) } returns
-            søknad(
-                søknadData.id,
-                søknadData.dokumentType,
-                søknadData.opprettetTid,
-            )
+                søknad(
+                    søknadData.id,
+                    søknadData.dokumentType,
+                    søknadData.opprettetTid,
+                )
     }
 
     private fun mockHentSøknaderForPerson(søknadData: List<SøknadData>) {
         every { søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
-            listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
-            søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
+                listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
+                søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
     }
 
     private fun ettersending(opprettetTid: LocalDateTime) = Ettersending(ettersendingJson = EncryptedString(""), stønadType = "OS", fnr = FNR, opprettetTid = opprettetTid)
 
     private fun mockHentEttersendingerForPerson(opprettetTid: LocalDateTime? = null) {
         every { ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR)) } returns
-            if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
+                if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
     }
 
     data class SøknadData(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -20,7 +20,6 @@ import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.prosessering.domene.Task
 import no.nav.tms.varsel.action.EksternKanal
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.net.URL
 import java.time.LocalDateTime
@@ -59,171 +58,168 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         every { ettersendingConfig.ettersendingUrl } returns URL("https://dummy-url.nav.no")
     }
 
-    @Nested
-    inner class SendPåminnelseOmDokumentasjonsbehovTilDittNav {
-        @Test
-        internal fun `ingen etterfølgende søknader, ingen innsendte ettersendinger - skal sende påminnelse`() {
-            val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
-            val forventetMelding =
-                lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson()
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
+    @Test
+    internal fun `ingen etterfølgende søknader, ingen innsendte ettersendinger - skal sende påminnelse`() {
+        val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
+        val forventetMelding =
+            lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson()
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                dittNavKafkaProducer.sendBeskjedTilBruker(
-                    personIdent = FNR,
-                    varselId = EVENT_ID,
-                    melding = eq(forventetMelding.melding),
-                    link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS,
-                )
-            }
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                personIdent = FNR,
+                varselId = EVENT_ID,
+                melding = eq(forventetMelding.melding),
+                link = forventetMelding.link.toString(),
+                eksternKanal = EksternKanal.SMS,
+            )
         }
+    }
 
-        @Test
-        internal fun `har etterfølgende søknad, ingen innsendte ettersendinger - skal ikke sende påminnelse`() {
-            val søknadData =
-                listOf(
-                    SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
-                    SøknadData(søknadIds.get(1), SøknadType.BARNETILSYN.dokumentType, LocalDateTime.now().plusDays(1)),
-                )
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson()
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
+    @Test
+    internal fun `har etterfølgende søknad, ingen innsendte ettersendinger - skal ikke sende påminnelse`() {
+        val søknadData =
+            listOf(
+                SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
+                SøknadData(søknadIds.get(1), SøknadType.BARNETILSYN.dokumentType, LocalDateTime.now().plusDays(1)),
+            )
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson()
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer wasNot called
-            }
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+            dittNavKafkaProducer wasNot called
         }
+    }
 
-        @Test
-        internal fun `ikke etterfølgende søknad, har innsendte ettersendinger - skal ikke sende påminnelse`() {
-            val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson(LocalDateTime.now().plusHours(1))
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
+    @Test
+    internal fun `ikke etterfølgende søknad, har innsendte ettersendinger - skal ikke sende påminnelse`() {
+        val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson(LocalDateTime.now().plusHours(1))
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer wasNot called
-            }
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+            dittNavKafkaProducer wasNot called
         }
+    }
 
-        @Test
-        internal fun `har etterfølgende søknad for arbeidssøker - skal sende påminnelse`() {
-            val søknadData =
-                listOf(
-                    SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
-                    SøknadData(søknadIds.get(1), SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER.dokumentType, LocalDateTime.now()),
-                )
-            val forventetMelding =
-                lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson()
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
+    @Test
+    internal fun `har etterfølgende søknad for arbeidssøker - skal sende påminnelse`() {
+        val søknadData =
+            listOf(
+                SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
+                SøknadData(søknadIds.get(1), SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER.dokumentType, LocalDateTime.now()),
+            )
+        val forventetMelding =
+            lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson()
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                dittNavKafkaProducer.sendBeskjedTilBruker(
-                    personIdent = FNR,
-                    varselId = EVENT_ID,
-                    melding = eq(forventetMelding.melding),
-                    link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS,
-                )
-            }
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                personIdent = FNR,
+                varselId = EVENT_ID,
+                melding = eq(forventetMelding.melding),
+                link = forventetMelding.link.toString(),
+                eksternKanal = EksternKanal.SMS,
+            )
         }
+    }
 
-        @Test
-        internal fun `har tidligere søknader, har tidligere ettersendinger - skal sende påminnelse`() {
-            val søknadData =
-                listOf(
-                    SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
-                    SøknadData(søknadIds.get(1), SøknadType.SKOLEPENGER.dokumentType, LocalDateTime.now().minusDays(1)),
-                )
-            val forventetMelding =
-                lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson(LocalDateTime.now().minusHours(1))
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
+    @Test
+    internal fun `har tidligere søknader, har tidligere ettersendinger - skal sende påminnelse`() {
+        val søknadData =
+            listOf(
+                SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()),
+                SøknadData(søknadIds.get(1), SøknadType.SKOLEPENGER.dokumentType, LocalDateTime.now().minusDays(1)),
+            )
+        val forventetMelding =
+            lagMeldingPåminnelseManglerDokumentasjonsbehov(ettersendingConfig.ettersendingUrl, "overgangsstønad")
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson(LocalDateTime.now().minusHours(1))
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                dittNavKafkaProducer.sendBeskjedTilBruker(
-                    personIdent = FNR,
-                    varselId = EVENT_ID,
-                    melding = eq(forventetMelding.melding),
-                    link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS,
-                )
-            }
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                personIdent = FNR,
+                varselId = EVENT_ID,
+                melding = eq(forventetMelding.melding),
+                link = forventetMelding.link.toString(),
+                eksternKanal = EksternKanal.SMS,
+            )
         }
+    }
 
-        @Test
-        internal fun `søknad har resultert i en påbegynt behandleSak oppgave - skal ikke sende påminnelse`() {
-            val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson()
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
+    @Test
+    internal fun `søknad har resultert i en påbegynt behandleSak oppgave - skal ikke sende påminnelse`() {
+        val søknadData = listOf(SøknadData(søknadIds.first(), SøknadType.OVERGANGSSTØNAD.dokumentType, LocalDateTime.now()))
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson()
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns true
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer wasNot called
-            }
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+            dittNavKafkaProducer wasNot called
         }
+    }
 
-        @Test
-        internal fun `stønadType er null - skal ikke sende påminnelse`() {
-            val søknadData = listOf(SøknadData(søknadIds.first(), "", LocalDateTime.now()))
-            mockHentSøknad(søknadData.first())
-            mockHentSøknaderForPerson(søknadData)
-            mockHentEttersendingerForPerson()
-            every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
+    @Test
+    internal fun `stønadType er null - skal ikke sende påminnelse`() {
+        val søknadData = listOf(SøknadData(søknadIds.first(), "", LocalDateTime.now()))
+        mockHentSøknad(søknadData.first())
+        mockHentSøknaderForPerson(søknadData)
+        mockHentEttersendingerForPerson()
+        every { saksbehandlingClient.kanSendePåminnelseTilBruker(any()) } returns false
 
-            sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
+        sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
-            verify(exactly = 1) {
-                søknadskvitteringService.hentSøknad(any())
-                søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
-                ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer wasNot called
-            }
+        verify(exactly = 1) {
+            søknadskvitteringService.hentSøknad(any())
+            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
+            dittNavKafkaProducer wasNot called
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -4,7 +4,6 @@ import io.mockk.called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal
 import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.featuretoggle.FeatureToggleService
@@ -79,15 +78,13 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                // TODO: Husk å fjerne meg.
-                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)// TODO: Fjern denne.
-                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                dittNavKafkaProducer.sendBeskjedTilBruker(
                     personIdent = FNR,
                     varselId = EVENT_ID,
                     melding = eq(forventetMelding.melding),
                     link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS
-                )*/
+                    eksternKanal = EksternKanal.SMS,
+                )
             }
         }
 
@@ -152,15 +149,13 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                // TODO: Husk å fjerne meg.
-                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)
-                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                dittNavKafkaProducer.sendBeskjedTilBruker(
                     personIdent = FNR,
                     varselId = EVENT_ID,
                     melding = eq(forventetMelding.melding),
                     link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS
-                )*/
+                    eksternKanal = EksternKanal.SMS,
+                )
             }
         }
 
@@ -185,15 +180,13 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
-                // TODO: Husk å fjerne meg.
-                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)
-                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                dittNavKafkaProducer.sendBeskjedTilBruker(
                     personIdent = FNR,
                     varselId = EVENT_ID,
                     melding = eq(forventetMelding.melding),
                     link = forventetMelding.link.toString(),
-                    eksternKanal = EksternKanal.SMS
-                )*/
+                    eksternKanal = EksternKanal.SMS,
+                )
             }
         }
 
@@ -248,24 +241,24 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
 
     private fun mockHentSøknad(søknadData: SøknadData) {
         every { søknadskvitteringService.hentSøknad(søknadIds.first()) } returns
-                søknad(
-                    søknadData.id,
-                    søknadData.dokumentType,
-                    søknadData.opprettetTid,
-                )
+            søknad(
+                søknadData.id,
+                søknadData.dokumentType,
+                søknadData.opprettetTid,
+            )
     }
 
     private fun mockHentSøknaderForPerson(søknadData: List<SøknadData>) {
         every { søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
-                listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
-                søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
+            listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
+            søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
     }
 
     private fun ettersending(opprettetTid: LocalDateTime) = Ettersending(ettersendingJson = EncryptedString(""), stønadType = "OS", fnr = FNR, opprettetTid = opprettetTid)
 
     private fun mockHentEttersendingerForPerson(opprettetTid: LocalDateTime? = null) {
         every { ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR)) } returns
-                if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
+            if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
     }
 
     data class SøknadData(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ef.mottak.util.lagMeldingPåminnelseManglerDokumentasjonsb
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.prosessering.domene.Task
+import no.nav.tms.varsel.action.EksternKanal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -77,7 +78,16 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknad(any())
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+
+                // TODO: Husk å fjerne meg.
+                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)// TODO: Fjern denne.
+                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                    personIdent = FNR,
+                    varselId = EVENT_ID,
+                    melding = eq(forventetMelding.melding),
+                    link = forventetMelding.link.toString(),
+                    eksternKanal = EksternKanal.SMS
+                )*/
             }
         }
 
@@ -141,7 +151,16 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknad(any())
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+
+                // TODO: Husk å fjerne meg.
+                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)
+                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                    personIdent = FNR,
+                    varselId = EVENT_ID,
+                    melding = eq(forventetMelding.melding),
+                    link = forventetMelding.link.toString(),
+                    eksternKanal = EksternKanal.SMS
+                )*/
             }
         }
 
@@ -165,7 +184,16 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
                 søknadskvitteringService.hentSøknad(any())
                 søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
                 ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
-                dittNavKafkaProducer.sendToKafka(FNR, eq(forventetMelding.melding), any(), EVENT_ID, forventetMelding.link, PreferertKanal.SMS)
+
+                // TODO: Husk å fjerne meg.
+                dittNavKafkaProducer.sendToKafka(fnr = FNR, melding = eq(forventetMelding.melding), grupperingsnummer = any(), eventId = EVENT_ID, link = forventetMelding.link, kanal = PreferertKanal.SMS)
+                /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                    personIdent = FNR,
+                    varselId = EVENT_ID,
+                    melding = eq(forventetMelding.melding),
+                    link = forventetMelding.link.toString(),
+                    eksternKanal = EksternKanal.SMS
+                )*/
             }
         }
 
@@ -220,24 +248,24 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
 
     private fun mockHentSøknad(søknadData: SøknadData) {
         every { søknadskvitteringService.hentSøknad(søknadIds.first()) } returns
-            søknad(
-                søknadData.id,
-                søknadData.dokumentType,
-                søknadData.opprettetTid,
-            )
+                søknad(
+                    søknadData.id,
+                    søknadData.dokumentType,
+                    søknadData.opprettetTid,
+                )
     }
 
     private fun mockHentSøknaderForPerson(søknadData: List<SøknadData>) {
         every { søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
-            listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
-            søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
+                listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
+                søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
     }
 
     private fun ettersending(opprettetTid: LocalDateTime) = Ettersending(ettersendingJson = EncryptedString(""), stønadType = "OS", fnr = FNR, opprettetTid = opprettetTid)
 
     private fun mockHentEttersendingerForPerson(opprettetTid: LocalDateTime? = null) {
         every { ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR)) } returns
-            if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
+                if (opprettetTid == null) emptyList() else listOf(ettersending(opprettetTid))
     }
 
     data class SøknadData(

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -84,12 +84,12 @@ internal class SendSøknadMottattTilDittNavTaskTest {
 
     private fun mockSøknad(søknadType: SøknadType) {
         every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
-                Søknad(
-                    id = SØKNAD_ID,
-                    søknadJson = EncryptedString(""),
-                    dokumenttype = søknadType.dokumentType,
-                    fnr = FNR,
-                )
+            Søknad(
+                id = SØKNAD_ID,
+                søknadJson = EncryptedString(""),
+                dokumenttype = søknadType.dokumentType,
+                fnr = FNR,
+            )
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -72,24 +72,32 @@ internal class SendSøknadMottattTilDittNavTaskTest {
     private fun verifiserForventetKallMed(forventetTekst: String) {
         verify(exactly = 1) {
             søknadskvitteringService.hentSøknad(any())
-            dittNavKafkaProducer.sendToKafka(
-                FNR,
-                forventetTekst,
-                task.payload,
-                EVENT_ID,
-                null,
+
+            // TODO: Husk å fjerne meg.
+           dittNavKafkaProducer.sendToKafka(
+                fnr = FNR,
+                melding = forventetTekst,
+                grupperingsnummer = task.payload,
+                eventId = EVENT_ID,
+                link = null,
             )
+
+            /*dittNavKafkaProducer.sendBeskjedTilBruker(
+                personIdent = FNR,
+                varselId = EVENT_ID,
+                melding = forventetTekst
+            )*/
         }
     }
 
     private fun mockSøknad(søknadType: SøknadType) {
         every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
-            Søknad(
-                id = SØKNAD_ID,
-                søknadJson = EncryptedString(""),
-                dokumenttype = søknadType.dokumentType,
-                fnr = FNR,
-            )
+                Søknad(
+                    id = SØKNAD_ID,
+                    søknadJson = EncryptedString(""),
+                    dokumenttype = søknadType.dokumentType,
+                    fnr = FNR,
+                )
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -73,31 +73,22 @@ internal class SendSøknadMottattTilDittNavTaskTest {
         verify(exactly = 1) {
             søknadskvitteringService.hentSøknad(any())
 
-            // TODO: Husk å fjerne meg.
-           dittNavKafkaProducer.sendToKafka(
-                fnr = FNR,
-                melding = forventetTekst,
-                grupperingsnummer = task.payload,
-                eventId = EVENT_ID,
-                link = null,
-            )
-
-            /*dittNavKafkaProducer.sendBeskjedTilBruker(
+            dittNavKafkaProducer.sendBeskjedTilBruker(
                 personIdent = FNR,
                 varselId = EVENT_ID,
-                melding = forventetTekst
-            )*/
+                melding = forventetTekst,
+            )
         }
     }
 
     private fun mockSøknad(søknadType: SøknadType) {
         every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
-                Søknad(
-                    id = SØKNAD_ID,
-                    søknadJson = EncryptedString(""),
-                    dokumenttype = søknadType.dokumentType,
-                    fnr = FNR,
-                )
+            Søknad(
+                id = SØKNAD_ID,
+                søknadJson = EncryptedString(""),
+                dokumenttype = søknadType.dokumentType,
+                fnr = FNR,
+            )
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ef.mottak.task.SendSøknadMottattTilDittNavTask
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.prosessering.domene.Task
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.Properties
 import java.util.UUID
@@ -38,35 +37,32 @@ internal class SendSøknadMottattTilDittNavTaskTest {
             )
     }
 
-    @Nested
-    inner class SøknadMottattTilDittNav {
-        @Test
-        internal fun `arbeidssøker skjema skal ha riktig tekst `() {
-            mockSøknad(SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER)
-            sendSøknadMottattTilDittNavTask.doTask(task)
-            verifiserForventetKallMed("Vi har mottatt skjema enslig mor eller far som er arbeidssøker.")
-        }
+    @Test
+    internal fun `arbeidssøker skjema skal ha riktig tekst `() {
+        mockSøknad(SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER)
+        sendSøknadMottattTilDittNavTask.doTask(task)
+        verifiserForventetKallMed("Vi har mottatt skjema enslig mor eller far som er arbeidssøker.")
+    }
 
-        @Test
-        internal fun `Overgangsstønad skal ha riktig tekst `() {
-            mockSøknad(SøknadType.OVERGANGSSTØNAD)
-            sendSøknadMottattTilDittNavTask.doTask(task)
-            verifiserForventetKallMed("Vi har mottatt søknaden din om overgangsstønad.")
-        }
+    @Test
+    internal fun `Overgangsstønad skal ha riktig tekst `() {
+        mockSøknad(SøknadType.OVERGANGSSTØNAD)
+        sendSøknadMottattTilDittNavTask.doTask(task)
+        verifiserForventetKallMed("Vi har mottatt søknaden din om overgangsstønad.")
+    }
 
-        @Test
-        internal fun `Barnetilsyn skal ha riktig tekst `() {
-            mockSøknad(SøknadType.BARNETILSYN)
-            sendSøknadMottattTilDittNavTask.doTask(task)
-            verifiserForventetKallMed("Vi har mottatt søknaden din om stønad til barnetilsyn.")
-        }
+    @Test
+    internal fun `Barnetilsyn skal ha riktig tekst `() {
+        mockSøknad(SøknadType.BARNETILSYN)
+        sendSøknadMottattTilDittNavTask.doTask(task)
+        verifiserForventetKallMed("Vi har mottatt søknaden din om stønad til barnetilsyn.")
+    }
 
-        @Test
-        internal fun `Skolepenger skal ha riktig tekst `() {
-            mockSøknad(SøknadType.SKOLEPENGER)
-            sendSøknadMottattTilDittNavTask.doTask(task)
-            verifiserForventetKallMed("Vi har mottatt søknaden din om stønad til skolepenger.")
-        }
+    @Test
+    internal fun `Skolepenger skal ha riktig tekst `() {
+        mockSøknad(SøknadType.SKOLEPENGER)
+        sendSøknadMottattTilDittNavTask.doTask(task)
+        verifiserForventetKallMed("Vi har mottatt søknaden din om stønad til skolepenger.")
     }
 
     private fun verifiserForventetKallMed(forventetTekst: String) {

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -11,6 +11,8 @@ import no.nav.familie.ef.mottak.task.SendDokumentasjonsbehovMeldingTilDittNavTas
 import no.nav.familie.ef.mottak.task.SendSøknadMottattTilDittNavTask
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.prosessering.domene.Task
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Varseltype
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.Properties
@@ -68,12 +70,12 @@ internal class SendSøknadMottattTilDittNavTaskTest {
     private fun verifiserForventetKallMed(forventetTekst: String) {
         verify(exactly = 1) {
             søknadskvitteringService.hentSøknad(any())
-            dittNavKafkaProducer.sendToKafka(
-                FNR,
-                forventetTekst,
-                task.payload,
-                EVENT_ID,
-                null,
+            dittNavKafkaProducer.sendBeskjedTilBruker(
+                type = Varseltype.Beskjed,
+                varselId = EVENT_ID,
+                ident = FNR,
+                melding = forventetTekst,
+                sensitivitet = Sensitivitet.High
             )
         }
     }

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -58,6 +58,7 @@ KAFKA_CREDSTORE_PASSWORD: password
 KAFKA_TRUSTSTORE_PATH: path
 
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering-v1
+BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 dittnav.soknadfrontendUrl: http://localhost:3000/familie/alene-med-barn/soknad
 EF_SAK_URL: http://localhost:8092/mockintegrasjoner/
@@ -74,6 +75,9 @@ TOKEN_X_PRIVATE_JWK: '{
 
 UNLEASH_SERVER_API_URL: http://localhost:4242/api
 UNLEASH_SERVER_API_TOKEN: token
+
 NAIS_APP_NAME: familie-ef-mottak
+NAIS_NAMESPACE: teamfamilie
+NAIS_CLUSTER_NAME: local
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -58,7 +58,6 @@ KAFKA_CREDSTORE_PASSWORD: password
 KAFKA_TRUSTSTORE_PATH: path
 
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering-v1
-BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 dittnav.soknadfrontendUrl: http://localhost:3000/familie/alene-med-barn/soknad
 EF_SAK_URL: http://localhost:8092/mockintegrasjoner/

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -82,6 +82,7 @@ KAFKA_CREDSTORE_PASSWORD: password
 KAFKA_TRUSTSTORE_PATH: path
 
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering-v1
+BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 dittnav.soknadfrontendUrl: http://localhost:3000/familie/alene-med-barn/soknad
 EF_SAK_URL: http://localhost:8092/mockintegrasjoner/

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -98,6 +98,9 @@ TOKEN_X_PRIVATE_JWK: '{
 
 UNLEASH_SERVER_API_URL: http://localhost:4242/api
 UNLEASH_SERVER_API_TOKEN: token
+
 NAIS_APP_NAME: familie-ef-mottak
+NAIS_NAMESPACE: teamfamilie
+NAIS_CLUSTER_NAME: local
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -82,7 +82,6 @@ KAFKA_CREDSTORE_PASSWORD: password
 KAFKA_TRUSTSTORE_PATH: path
 
 JOURNALFOERINGHENDELSE_V1_TOPIC_URL: teamdokumenthandtering.aapen-dok-journalfoering-v1
-BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 dittnav.soknadfrontendUrl: http://localhost:3000/familie/alene-med-barn/soknad
 EF_SAK_URL: http://localhost:8092/mockintegrasjoner/


### PR DESCRIPTION
# Brukervarsel migrering for nytt kafka topic

### Hvorfor er denne endringen nødvendig? ✨ 

Den gamle måten på å sende brukernotifikasjon er på vei ut det er nå bedt om å migrere over til det nye topicet. Derfor har man prøvd å gjøre slik man allerede har gjort i `familie-ef-sak` og `familie-ef-iverkesett`, der man allerede har den nye implementasjonen på plass. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24075).

Migreringsguide finner du → [her](https://navikt.github.io/tms-dokumentasjon/varsler/migrere/). 

**Hovedsaklig er endringene:**

Endring av feltnavn

* `eventId` → `varselId`
* `sikkerhetsnivaa` → `sensitivitet` (`3` → `substantial`, `4` → `high`)
* `synligFremTil` → `aktivFremTil`
* `fodselsnummer` → `ident`

Deprecated felter

* `grupperingsId`
* `tidspunkt` (håndteres et annet sted)

### Verdt å nevne

Det har faktisk ikke vært helt enkelt å teste dette enda, så før vi merger må vi passe på at dette fungerer og at forventet tekster dukker opp, spesielt på ekstern varsling (SMS). 