### PR TITLE
TokenValidation oppgradering restore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250128112334_99d3496</prosessering.version>
         <confluent.version>7.8.0</confluent.version>
         <kontrakter.version>3.0_20250206092356_0b11dc0</kontrakter.version>
-        <token-validation.version>5.0.14</token-validation.version>
+        <token-validation.version>5.0.16</token-validation.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
         <start-class>no.nav.familie.ef.mottak.ApplicationKt</start-class>
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/IntegrasjonSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/IntegrasjonSpringRunnerTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -68,7 +68,7 @@ abstract class IntegrasjonSpringRunnerTest {
     @LocalServerPort
     private var port: Int? = 0
 
-    @BeforeEach
+    @AfterEach
     fun reset() {
         loggingEvents.clear()
         dokumentasjonsbehovRepository.deleteAll()


### PR DESCRIPTION
Klarte å snike med en token validation downgrade i [PRen for uthenting av SistInnsendtSøknadDto](https://github.com/navikt/familie-ef-mottak/pull/1232). Vi endrer nå tilbake til riktig token validation bump.