### PR TITLE
Bug - språk blir sendt med til felt mappere for håndtering av "ja" og "nei"

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvittering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvittering.kt
@@ -17,7 +17,10 @@ object FeltformatererPdfKvittering {
     /**
      * Håndterer formatering utover vanlig toString for endenodene
      */
-    fun genereltFormatMapperMapEndenode(entitet: Søknadsfelt<*>): VerdilisteElement? {
+    fun genereltFormatMapperMapEndenode(
+        entitet: Søknadsfelt<*>,
+        språk: String,
+    ): VerdilisteElement? {
         // skal ekskluderes
         val skalEkskluderes =
             ((entitet.label == "Jeg har sendt inn denne dokumentasjonen til Nav tidligere" || entitet.label == "I have already submitted this documentation to Nav in the past") && entitet.verdi.toString() == "false") ||
@@ -26,31 +29,36 @@ object FeltformatererPdfKvittering {
         if (skalEkskluderes) {
             return null
         }
-        return mapTilVerdiListeElement(entitet)
+        return mapTilVerdiListeElement(entitet, språk)
     }
 
     fun mapVedlegg(vedleggTitler: List<String>): VerdilisteElement = VerdilisteElement("Vedlegg", verdi = vedleggTitler.joinToString("\n\n"))
 
-    private fun mapTilVerdiListeElement(entitet: Søknadsfelt<*>) =
-        VerdilisteElement(
-            entitet.label,
-            verdi = mapVerdi(entitet.verdi!!),
-            alternativer = entitet.alternativer?.joinToString(" / "),
-        )
+    private fun mapTilVerdiListeElement(
+        entitet: Søknadsfelt<*>,
+        språk: String,
+    ) = VerdilisteElement(
+        entitet.label,
+        verdi = mapVerdi(entitet.verdi!!, språk),
+        alternativer = entitet.alternativer?.joinToString(" / "),
+    )
 
-    private fun mapVerdi(verdi: Any): String =
+    private fun mapVerdi(
+        verdi: Any,
+        språk: String,
+    ): String =
         when (verdi) {
             is Month ->
                 tilUtskriftsformat(verdi)
 
             is Boolean ->
-                tilUtskriftsformat(verdi)
+                tilUtskriftsformat(verdi, språk)
 
             is Double ->
                 tilUtskriftsformat(verdi)
 
             is List<*> ->
-                verdi.joinToString("\n\n") { mapVerdi(it!!) }
+                verdi.joinToString("\n\n") { mapVerdi(it!!, språk) }
 
             is Fødselsnummer ->
                 verdi.verdi
@@ -74,7 +82,19 @@ object FeltformatererPdfKvittering {
                 verdi.toString()
         }
 
-    private fun tilUtskriftsformat(verdi: Boolean) = if (verdi) "Ja" else "Nei"
+    private fun tilUtskriftsformat(
+        verdi: Boolean,
+        språk: String,
+    ): String =
+        if (språk == "en") {
+            englishResponse(verdi)
+        } else {
+            norwegianResponse(verdi)
+        }
+
+    private fun englishResponse(verdi: Boolean) = if (verdi) "Yes" else "No"
+
+    private fun norwegianResponse(verdi: Boolean) = if (verdi) "Ja" else "Nei"
 
     private fun tilUtskriftsformat(verdi: Double) = String.format("%.2f", verdi).replace(".", ",")
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvitteringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/FeltformatererPdfKvitteringTest.kt
@@ -19,7 +19,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer Month korrekt`() {
         val testverdi = Søknadsfelt("label", Month.DECEMBER)
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "desember"))
     }
@@ -28,7 +28,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer Boolean korrekt`() {
         val testverdi = Søknadsfelt("label", true)
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ja"))
     }
@@ -37,7 +37,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer liste med Boolean korrekt`() {
         val testverdi = Søknadsfelt("label", listOf(true, false))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ja\n\nNei"))
     }
@@ -46,7 +46,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer List korrekt`() {
         val testverdi = Søknadsfelt<List<*>>("label", listOf("Lille", "Grimme", "Arne", "Trenger", "Ris"))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Lille\n\nGrimme\n\nArne\n\nTrenger\n\nRis"))
     }
@@ -56,7 +56,7 @@ internal class FeltformatererPdfKvitteringTest {
         val fnr = FnrGenerator.generer()
         val testverdi = Søknadsfelt("label", Fødselsnummer(fnr))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = fnr))
     }
@@ -65,7 +65,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer Adresse korrekt`() {
         val testverdi = Søknadsfelt("label", Adresse("Husebyskogen 15", "1572", "Fet", "Norge"))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n1572 Fet\nNorge"))
     }
@@ -74,7 +74,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap håndterer adresse med tomme felter korrekt`() {
         val testverdi = Søknadsfelt("label", Adresse("", "", "", ""))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Ingen registrert adresse"))
     }
@@ -83,7 +83,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap håndterer adresse med delvis utfylte felter korrekt`() {
         val testverdi = Søknadsfelt("label", Adresse("Husebyskogen 15", "", "Fet", ""))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Husebyskogen 15\n Fet"))
     }
@@ -92,7 +92,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap håndterer adresse med kun land`() {
         val testverdi = Søknadsfelt("label", Adresse("", "", "", "Norge"))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Norge"))
     }
@@ -101,7 +101,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer LocalDate korrekt`() {
         val testverdi = Søknadsfelt<LocalDate>("label", LocalDate.of(2015, 12, 5))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "05.12.2015"))
     }
@@ -110,7 +110,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer LocalDateTime korrekt`() {
         val testverdi = Søknadsfelt<LocalDateTime>("label", LocalDateTime.of(2015, 12, 5, 14, 52, 48))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "05.12.2015 14:52:48"))
     }
@@ -119,7 +119,7 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer MånedÅrPeriode korrekt`() {
         val testverdi = Søknadsfelt("label", MånedÅrPeriode(Month.FEBRUARY, 2015, Month.JULY, 2018))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Fra februar 2015 til juli 2018"))
     }
@@ -128,8 +128,12 @@ internal class FeltformatererPdfKvitteringTest {
     fun `mapEndenodeTilUtskriftMap formaterer Datoperiode korrekt`() {
         val testverdi = Søknadsfelt("label", Datoperiode(LocalDate.of(2015, 2, 1), LocalDate.of(2018, 7, 14)))
 
-        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi)
+        val resultat = FeltformatererPdfKvittering.genereltFormatMapperMapEndenode(testverdi, SPRÅK)
 
         assertThat(resultat).isEqualTo(VerdilisteElement(label = "label", verdi = "Fra 01.02.2015 til 14.07.2018"))
+    }
+
+    companion object {
+        private const val SPRÅK = "nb"
     }
 }


### PR DESCRIPTION
# Språk blir sendt med til felt mappere for håndtering av "ja" og "nei"

### Hvorfor er denne endringen nødvendig? ✨ 

Vi sender nå med språk ned til feltmapperne for å håndtere "ja" og "nei". Dette er ikke en ideell løsning på lang sikt, men det er den raskeste veien til mål akkurat nå. Denne løsningen kan leve med at den må refaktoreres senere, da utfordringen fra søknad til kvittering er at språk og tekster dikteres i ulike ledd.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24127).

### Verdt å nevne

Det er fortsatt noen norske etiketter i søknadskvitteringen, som "vedlegg" osv. Dette blir tatt hensyn til, siden vi mener dette er godt nok akkurat nå.