### PR TITLE
renamet fra søknadskvitteringController til søknadController

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/PersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/PersonController.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.mottak.api
 
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.kontrakter.ef.ettersending.SøknadMedDokumentasjonsbehovDto
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.sikkerhet.EksternBrukerUtils
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
     claimMap = ["acr=Level4"],
 )
 class PersonController(
-    val søknadskvitteringService: SøknadskvitteringService,
+    val søknadService: SøknadService,
 ) {
     @PostMapping("soknader")
     fun søknaderForPerson(
@@ -29,6 +29,6 @@ class PersonController(
         if (!EksternBrukerUtils.personIdentErLikInnloggetBruker(personIdent.ident)) {
             throw ApiFeil("Fnr fra token matcher ikke fnr i request", HttpStatus.FORBIDDEN)
         }
-        return ResponseEntity.ok().body(søknadskvitteringService.hentDokumentasjonsbehovForPerson(personIdent.ident))
+        return ResponseEntity.ok().body(søknadService.hentDokumentasjonsbehovForPerson(personIdent.ident))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.mottak.api
 
 import no.nav.familie.ef.mottak.api.dto.Kvittering
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.util.okEllerKastException
 import no.nav.familie.kontrakter.ef.søknad.SkjemaForArbeidssøker
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
@@ -25,37 +25,37 @@ import org.springframework.web.bind.annotation.RestController
     claimMap = ["acr=Level4"],
 )
 class SøknadController(
-    val søknadKvitteringService: SøknadskvitteringService,
+    val søknadService: SøknadService,
 ) {
     @PostMapping("overgangsstonad")
     fun mottaSøknadOvergangsstønad(
         @RequestBody søknad: SøknadMedVedlegg<SøknadOvergangsstønad>,
-    ): Kvittering = okEllerKastException { søknadKvitteringService.mottaSøknadOvergangsstønad(søknad) }
+    ): Kvittering = okEllerKastException { søknadService.mottaSøknadOvergangsstønad(søknad) }
 
     @PostMapping("barnetilsyn")
     fun mottaSøknadBarnetilsyn(
         @RequestBody søknad: SøknadMedVedlegg<SøknadBarnetilsyn>,
-    ): Kvittering = okEllerKastException { søknadKvitteringService.mottaSøknadBarnetilsyn(søknad) }
+    ): Kvittering = okEllerKastException { søknadService.mottaSøknadBarnetilsyn(søknad) }
 
     @PostMapping("skolepenger")
     fun mottaSøknadSkolepenger(
         @RequestBody søknad: SøknadMedVedlegg<SøknadSkolepenger>,
-    ): Kvittering = okEllerKastException { søknadKvitteringService.mottaSøknadSkolepenger(søknad) }
+    ): Kvittering = okEllerKastException { søknadService.mottaSøknadSkolepenger(søknad) }
 
     @PostMapping("arbeidssoker")
     fun mottaArbeidssøkerSkjema(
         @RequestBody skjemaForArbeidssøker: SkjemaForArbeidssøker,
-    ): Kvittering = okEllerKastException { søknadKvitteringService.mottaArbeidssøkerSkjema(skjemaForArbeidssøker) }
+    ): Kvittering = okEllerKastException { søknadService.mottaArbeidssøkerSkjema(skjemaForArbeidssøker) }
 
     @GetMapping("barnetilsyn/forrige")
     fun hentBarnetilsynssøknadForPerson(): SøknadBarnetilsyn? {
         val personIdent = EksternBrukerUtils.hentFnrFraToken()
-        return søknadKvitteringService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent)
+        return søknadService.hentBarnetilsynSøknadsverdierTilGjenbruk(personIdent)
     }
 
     @GetMapping("sist-innsendt-per-stonad")
     fun hentSistInnsendtSøknadPerStønad(): List<SistInnsendtSøknadDto> {
         val personIdent = EksternBrukerUtils.hentFnrFraToken()
-        return søknadKvitteringService.hentSistInnsendtSøknadPerStønad(personIdent)
+        return søknadService.hentSistInnsendtSøknadPerStønad(personIdent)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/api/SøknadController.kt
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(path = ["api/soknadskvittering", "/api/soknad"], produces = [APPLICATION_JSON_VALUE])
+@RequestMapping("/api/soknad", produces = [APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(
     issuer = EksternBrukerUtils.ISSUER_TOKENX,
     claimMap = ["acr=Level4"],
 )
-class SøknadskvitteringController(
+class SøknadController(
     val søknadKvitteringService: SøknadskvitteringService,
 ) {
     @PostMapping("overgangsstonad")

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/ArkiveringService.kt
@@ -22,7 +22,7 @@ import org.springframework.web.client.HttpClientErrorException
 @Service
 class ArkiveringService(
     private val integrasjonerClient: IntegrasjonerClient,
-    private val søknadKvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
     private val ettersendingService: EttersendingService,
     private val vedleggRepository: VedleggRepository,
     private val ettersendingVedleggRepository: EttersendingVedleggRepository,
@@ -34,7 +34,7 @@ class ArkiveringService(
         callId: String,
     ): String {
         logger.info("Henter ut søknad")
-        val søknad: Søknad = søknadKvitteringService.hentSøknad(søknadId)
+        val søknad: Søknad = søknadService.hentSøknad(søknadId)
         logger.info("Henter ut vedlegg")
         val vedlegg = vedleggRepository.findBySøknadId(søknad.id)
         logger.info("Journalfører søknad med vedlegg")
@@ -45,7 +45,7 @@ class ArkiveringService(
 
         val søknadMedJournalpostId = søknad.copy(journalpostId = journalpostId)
         logger.info("Oppdaterer søknad med journalpostId")
-        søknadKvitteringService.oppdaterSøknad(søknadMedJournalpostId)
+        søknadService.oppdaterSøknad(søknadMedJournalpostId)
         return journalpostId
     }
 
@@ -65,7 +65,7 @@ class ArkiveringService(
     }
 
     fun ferdigstillJournalpost(søknadId: String) {
-        val søknad: Søknad = søknadKvitteringService.hentSøknad(søknadId)
+        val søknad: Søknad = søknadService.hentSøknad(søknadId)
         val journalpostId: String = søknad.journalpostId ?: error("Søknad=$søknadId mangler journalpostId")
 
         val enheter = integrasjonerClient.finnBehandlendeEnhet(søknad.fnr)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/MappeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/MappeService.kt
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service
 @Service
 class MappeService(
     private val integrasjonerClient: IntegrasjonerClient,
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
     private val cacheManager: CacheManager,
 ) {
     val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -58,7 +58,7 @@ class MappeService(
         }
 
     private fun finnSøkestrengForSøknad(søknadId: String): MappeSøkestreng {
-        val søknad = søknadskvitteringService.hentSøknad(søknadId)
+        val søknad = søknadService.hentSøknad(søknadId)
 
         return when (dokumenttypeTilStønadType(søknad.dokumenttype)) {
             StønadType.OVERGANGSSTØNAD -> mappeFraOvergangsstønad(søknad)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/OppgaveService.kt
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service
 @Service
 class OppgaveService(
     private val integrasjonerClient: IntegrasjonerClient,
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
     private val ettersendingService: EttersendingService,
     private val opprettOppgaveMapper: OpprettOppgaveMapper,
     private val mappeService: MappeService,
@@ -32,7 +32,7 @@ class OppgaveService(
     val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
 
     fun lagJournalføringsoppgaveForSøknadId(søknadId: String): Long? {
-        val søknad: Søknad = søknadskvitteringService.hentSøknad(søknadId)
+        val søknad: Søknad = søknadService.hentSøknad(søknadId)
         val journalpostId: String = søknad.journalpostId ?: error("Søknad mangler journalpostId")
         val journalpost = integrasjonerClient.hentJournalpost(journalpostId)
         val prioritet = UtledPrioritetForSøknadUtil.utledPrioritet(søknad)

--- a/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/service/SøknadService.kt
@@ -39,7 +39,7 @@ import no.nav.familie.kontrakter.ef.søknad.Vedlegg as VedleggFamilieKontrakter
 
 @Service
 @Transactional
-class SøknadskvitteringService(
+class SøknadService(
     private val søknadRepository: SøknadRepository,
     private val vedleggRepository: VedleggRepository,
     private val dokumentClient: FamilieDokumentClient,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTask.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.AutomatiskJournalføringService
 import no.nav.familie.ef.mottak.service.MappeService
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.util.dokumenttypeTilStønadType
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service
 @Service
 @TaskStepBeskrivelse(taskStepType = AutomatiskJournalførTask.TYPE, beskrivelse = "Automatisk journalfør")
 class AutomatiskJournalførTask(
-    val søknadskvitteringService: SøknadskvitteringService,
+    val søknadService: SøknadService,
     val taskService: TaskService,
     val automatiskJournalføringService: AutomatiskJournalføringService,
     val integrasjonerClient: IntegrasjonerClient,
@@ -30,7 +30,7 @@ class AutomatiskJournalførTask(
     val antallAutomatiskJournalført: Counter = counter("alene.med.barn.automatiskjournalfort")
 
     override fun doTask(task: Task) {
-        val søknad: Søknad = søknadskvitteringService.hentSøknad(task.payload)
+        val søknad: Søknad = søknadService.hentSøknad(task.payload)
         val stønadstype: StønadType =
             dokumenttypeTilStønadType(søknad.dokumenttype) ?: error("Må ha stønadstype for å automatisk journalføre")
         val journalpostId = task.metadata["journalpostId"].toString()

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTask.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.mottak.task
 import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.util.LinkMelding
 import no.nav.familie.ef.mottak.util.lagMeldingManglerDokumentasjonsbehov
 import no.nav.familie.ef.mottak.util.lagMeldingSøknadMottattBekreftelse
@@ -24,19 +24,19 @@ import org.springframework.stereotype.Service
 )
 class SendDokumentasjonsbehovMeldingTilDittNavTask(
     private val producer: DittNavKafkaProducer,
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
     private val taskService: TaskService,
     private val ettersendingConfig: EttersendingConfig,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun doTask(task: Task) {
-        val søknad = søknadskvitteringService.hentSøknad(task.payload)
+        val søknad = søknadService.hentSøknad(task.payload)
         val søknadType = SøknadType.hentSøknadTypeForDokumenttype(søknad.dokumenttype)
         if (søknadType == SøknadType.OVERGANGSSTØNAD_ARBEIDSSØKER) {
             return
         }
-        val dokumentasjonsbehov = søknadskvitteringService.hentDokumentasjonsbehovForSøknad(søknad).dokumentasjonsbehov
+        val dokumentasjonsbehov = søknadService.hentDokumentasjonsbehovForSøknad(søknad).dokumentasjonsbehov
         if (dokumentasjonsbehov.isNotEmpty()) {
             val manglerVedleggPåSøknad = manglerVedlegg(dokumentasjonsbehov)
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
 import no.nav.familie.ef.mottak.service.EttersendingService
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.task.SendPåminnelseOmDokumentasjonsbehovTilDittNavTask.Companion.TYPE
 import no.nav.familie.ef.mottak.util.LinkMelding
 import no.nav.familie.ef.mottak.util.dokumenttypeTilStønadType
@@ -35,7 +35,7 @@ import java.util.UUID
 )
 class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
     private val producer: DittNavKafkaProducer,
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
     private val ettersendingService: EttersendingService,
     private val ettersendingConfig: EttersendingConfig,
     private val saksbehandlingClient: SaksbehandlingClient,
@@ -51,9 +51,9 @@ class SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
         counter("alene.med.barn.dokumentasjonsbehovvarslingstoppet.saksbehandlerogbruker")
 
     override fun doTask(task: Task) {
-        val søknad = søknadskvitteringService.hentSøknad(task.payload)
+        val søknad = søknadService.hentSøknad(task.payload)
         val personIdent = PersonIdent(søknad.fnr)
-        val søknader = søknadskvitteringService.hentSøknaderForPerson(personIdent)
+        val søknader = søknadService.hentSøknaderForPerson(personIdent)
         val ettersendinger = ettersendingService.hentEttersendingerForPerson(personIdent)
         val stønadstype: StønadType? = dokumenttypeTilStønadType(søknad.dokumenttype)
 

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.mottak.task
 
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.task.SendSøknadMottattTilDittNavTask.Companion.TYPE
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -17,12 +17,12 @@ import org.springframework.stereotype.Service
 )
 class SendSøknadMottattTilDittNavTask(
     private val producer: DittNavKafkaProducer,
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun doTask(task: Task) {
-        val søknad = søknadskvitteringService.hentSøknad(task.payload)
+        val søknad = søknadService.hentSøknad(task.payload)
 
         producer.sendBeskjedTilBruker(
             personIdent = søknad.fnr,

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SøknadsreduksjonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SøknadsreduksjonTask.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.mottak.task
 
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -13,11 +13,11 @@ import org.springframework.transaction.annotation.Transactional
     beskrivelse = "Resuserer datasomfanget for en søknad.",
 )
 class SøknadsreduksjonTask(
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
 ) : AsyncTaskStep {
     @Transactional
     override fun doTask(task: Task) {
-        søknadskvitteringService.reduserSøknad(task.payload)
+        søknadService.reduserSøknad(task.payload)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/SøknadsslettingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/SøknadsslettingTask.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.mottak.task
 
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -13,11 +13,11 @@ import org.springframework.transaction.annotation.Transactional
     beskrivelse = "Sletter en søknad fra mottak",
 )
 class SøknadsslettingTask(
-    private val søknadskvitteringService: SøknadskvitteringService,
+    private val søknadService: SøknadService,
 ) : AsyncTaskStep {
     @Transactional
     override fun doTask(task: Task) {
-        søknadskvitteringService.slettSøknad(task.payload)
+        søknadService.slettSøknad(task.payload)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/mottak/task/VelgAutomatiskEllerManuellFlytTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/mottak/task/VelgAutomatiskEllerManuellFlytTask.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.mottak.task
 
 import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.util.dokumenttypeTilStønadType
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.ef.StønadType.BARNETILSYN
@@ -21,11 +21,11 @@ import org.springframework.stereotype.Service
 )
 class VelgAutomatiskEllerManuellFlytTask(
     val taskService: TaskService,
-    val søknadskvitteringService: SøknadskvitteringService,
+    val søknadService: SøknadService,
     val saksbehandlingClient: SaksbehandlingClient,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val søknad: Søknad = søknadskvitteringService.hentSøknad(task.payload)
+        val søknad: Søknad = søknadService.hentSøknad(task.payload)
         val stønadstype: StønadType? = dokumenttypeTilStønadType(søknad.dokumenttype)
 
         val neste =

--- a/src/test/kotlin/no/nav/familie/ef/mottak/api/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/api/SøknadControllerTest.kt
@@ -18,7 +18,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.util.UUID
 
-internal class SøknadskvitteringControllerTest : IntegrasjonSpringRunnerTest() {
+internal class SøknadControllerTest : IntegrasjonSpringRunnerTest() {
     @Autowired
     lateinit var søknadRepository: SøknadRepository
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/ArkiveringServiceTest.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 
 internal class ArkiveringServiceTest {
     private val integrasjonerClient: IntegrasjonerClient = mockk()
-    private val søknadskvitteringService: SøknadskvitteringService = mockk()
+    private val søknadService: SøknadService = mockk()
     private val ettersendingService: EttersendingService = mockk(relaxed = true)
     private val vedleggRepository: VedleggRepository = mockk()
     private val ettersendingVedleggRepository: EttersendingVedleggRepository = mockk(relaxed = true)
@@ -38,7 +38,7 @@ internal class ArkiveringServiceTest {
     val arkiveringService =
         ArkiveringService(
             integrasjonerClient,
-            søknadskvitteringService,
+            søknadService,
             ettersendingService,
             vedleggRepository,
             ettersendingVedleggRepository,
@@ -86,8 +86,8 @@ internal class ArkiveringServiceTest {
         val forventetJounalføringsId = "1234"
         val forventetFeil = lagRessursException(conflictException)
         val journalposter = listOf(lagJournalpost(forventetJounalføringsId, "callId"))
-        every { søknadskvitteringService.hentSøknad(any()) } returns søknad
-        every { søknadskvitteringService.oppdaterSøknad(any()) } just Runs
+        every { søknadService.hentSøknad(any()) } returns søknad
+        every { søknadService.oppdaterSøknad(any()) } just Runs
         every { integrasjonerClient.arkiver(any()) } throws forventetFeil
         every { integrasjonerClient.hentJournalposterForBruker(any()) } returns journalposter
         every { vedleggRepository.findBySøknadId(any()) } returns emptyList()
@@ -109,8 +109,8 @@ internal class ArkiveringServiceTest {
     @Test
     internal fun `Skal ikke prøve å håndtere feil som ikke er av type conflict-409 for arkivering av søknader`() {
         val feil = HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR)
-        every { søknadskvitteringService.hentSøknad(any()) } returns søknad
-        every { søknadskvitteringService.oppdaterSøknad(any()) } just Runs
+        every { søknadService.hentSøknad(any()) } returns søknad
+        every { søknadService.oppdaterSøknad(any()) } just Runs
         every { integrasjonerClient.arkiver(any()) } throws lagRessursException(feil)
         every { vedleggRepository.findBySøknadId(any()) } returns emptyList()
         val ressursException =

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/MappeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/MappeServiceTest.kt
@@ -16,10 +16,10 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 
 internal class MappeServiceTest {
     private val integrasjonerClient: IntegrasjonerClient = mockk()
-    private val søknadskvitteringService: SøknadskvitteringService = mockk()
+    private val søknadService: SøknadService = mockk()
     private val cacheManager = ConcurrentMapCacheManager()
 
-    val mappeService = MappeService(integrasjonerClient, søknadskvitteringService, cacheManager)
+    val mappeService = MappeService(integrasjonerClient, søknadService, cacheManager)
 
     val søknadId = "123"
     val enhet = "4489"
@@ -27,7 +27,7 @@ internal class MappeServiceTest {
     @BeforeEach
     internal fun setUp() {
         every {
-            søknadskvitteringService.hentSøknad("123")
+            søknadService.hentSøknad("123")
         } returns
             Søknad(
                 søknadJson = EncryptedString(objectMapper.writeValueAsString(Testdata.søknadOvergangsstønad)),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/OppgaveServiceTest.kt
@@ -62,7 +62,7 @@ import kotlin.test.assertEquals
 
 internal class OppgaveServiceTest {
     private val integrasjonerClient: IntegrasjonerClient = mockk()
-    private val søknadskvitteringService: SøknadskvitteringService = mockk()
+    private val søknadService: SøknadService = mockk()
     private val opprettOppgaveMapper = spyk(OpprettOppgaveMapper())
     private val ettersendingService = mockk<EttersendingService>()
     private val cacheManager = ConcurrentMapCacheManager()
@@ -70,10 +70,10 @@ internal class OppgaveServiceTest {
     private val oppgaveService: OppgaveService =
         OppgaveService(
             integrasjonerClient = integrasjonerClient,
-            søknadskvitteringService = søknadskvitteringService,
+            søknadService = søknadService,
             opprettOppgaveMapper = opprettOppgaveMapper,
             ettersendingService = ettersendingService,
-            mappeService = MappeService(integrasjonerClient, søknadskvitteringService, cacheManager),
+            mappeService = MappeService(integrasjonerClient, søknadService, cacheManager),
         )
 
     @BeforeEach
@@ -129,7 +129,7 @@ internal class OppgaveServiceTest {
             )
         every { integrasjonerClient.finnOppgaver(any(), any()) } returns FinnOppgaveResponseDto(0L, emptyList())
         every {
-            søknadskvitteringService.hentSøknad("123")
+            søknadService.hentSøknad("123")
         } returns
             Søknad(
                 søknadJson = EncryptedString("{}"),
@@ -196,7 +196,7 @@ internal class OppgaveServiceTest {
         fun `skal opprette en ny oppgave for søknad`() {
             val søknadId = "enSøknadId"
             val journalpostId = "999"
-            every { søknadskvitteringService.hentSøknad(søknadId) } returns
+            every { søknadService.hentSøknad(søknadId) } returns
                 Søknad(
                     søknadJson = EncryptedString("{}"),
                     dokumenttype = DOKUMENTTYPE_OVERGANGSSTØNAD,
@@ -205,7 +205,7 @@ internal class OppgaveServiceTest {
                     behandleINySaksbehandling = true,
                 )
             every {
-                søknadskvitteringService.hentSøknad(any())
+                søknadService.hentSøknad(any())
             } returns
                 Søknad(
                     søknadJson = EncryptedString(objectMapper.writeValueAsString(Testdata.søknadOvergangsstønad)),
@@ -291,7 +291,7 @@ internal class OppgaveServiceTest {
             val sommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
-            every { søknadskvitteringService.hentSøknad(soknadId) } returns
+            every { søknadService.hentSøknad(soknadId) } returns
                 SøknadMapper
                     .fromDto(
                         Testdata.søknadOvergangsstønad.copy(
@@ -318,7 +318,7 @@ internal class OppgaveServiceTest {
             val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 5, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
-            every { søknadskvitteringService.hentSøknad(soknadId) } returns
+            every { søknadService.hentSøknad(soknadId) } returns
                 SøknadMapper
                     .fromDto(
                         Testdata.søknadOvergangsstønad.copy(
@@ -345,7 +345,7 @@ internal class OppgaveServiceTest {
             val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
-            every { søknadskvitteringService.hentSøknad(soknadId) } returns
+            every { søknadService.hentSøknad(soknadId) } returns
                 SøknadMapper
                     .fromDto(
                         Testdata.søknadOvergangsstønad.copy(
@@ -372,7 +372,7 @@ internal class OppgaveServiceTest {
             val utenforSommertid = LocalDate.of(LocalDateTime.now().year, 7, 20)
 
             every { integrasjonerClient.hentJournalpost(any()) } returns journalpost
-            every { søknadskvitteringService.hentSøknad(soknadId) } returns
+            every { søknadService.hentSøknad(soknadId) } returns
                 SøknadMapper
                     .fromDto(
                         Testdata.søknadBarnetilsyn.copy(
@@ -422,7 +422,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
 
-            every { søknadskvitteringService.hentSøknad(any()) } returns søknadBarnetilsyn()
+            every { søknadService.hentSøknad(any()) } returns søknadBarnetilsyn()
 
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "1")
 
@@ -447,7 +447,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad("123") } returns søknadOvergangsstønad(erSelvstendig = true)
+            every { søknadService.hentSøknad("123") } returns søknadOvergangsstønad(erSelvstendig = true)
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "123")
 
             assertThat(oppgaveSlot.captured.mappeId).isEqualTo(gammelMappeIdSelvstendig.toLong())
@@ -474,7 +474,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad("123") } returns
+            every { søknadService.hentSøknad("123") } returns
                 søknadOvergangsstønad(
                     erSelvstendig = true,
                     harTilsynskrevendeBarn = true,
@@ -505,7 +505,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad("123") } returns
+            every { søknadService.hentSøknad("123") } returns
                 søknadBarnetilsyn(
                     erSelvstendig = true,
                     harTilsynskrevendeBarn = true,
@@ -536,7 +536,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad("123") } returns
+            every { søknadService.hentSøknad("123") } returns
                 søknadBarnetilsyn(
                     erSelvstendig = true,
                     harTilsynskrevendeBarn = false,
@@ -567,7 +567,7 @@ internal class OppgaveServiceTest {
             val søknadBarnetilsyn =
                 objectMapper.readValue<SøknadBarnetilsyn>(IOTestUtil.readFile("barnetilsyn_særlige_tilsynsbehov_soknad.json"))
 
-            every { søknadskvitteringService.hentSøknad("123") } returns SøknadMapper.fromDto(søknadBarnetilsyn, true)
+            every { søknadService.hentSøknad("123") } returns SøknadMapper.fromDto(søknadBarnetilsyn, true)
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "123")
 
             assertThat(oppgaveSlot.captured.mappeId).isEqualTo(gammelMappeIdTilsynskrevende.toLong())
@@ -591,7 +591,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad("123") } returns søknadOvergangsstønad(false)
+            every { søknadService.hentSøknad("123") } returns søknadOvergangsstønad(false)
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "123")
 
             verify(exactly = 0) { integrasjonerClient.oppdaterOppgave(any(), any()) }
@@ -620,7 +620,7 @@ internal class OppgaveServiceTest {
                     behandlingstema = Behandlingstema.Skolepenger,
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
-            every { søknadskvitteringService.hentSøknad(any()) } returns søknadSkolepenger()
+            every { søknadService.hentSøknad(any()) } returns søknadSkolepenger()
 
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "-1")
 
@@ -667,7 +667,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad(any()) } returns søknadBarnetilsyn()
+            every { søknadService.hentSøknad(any()) } returns søknadBarnetilsyn()
 
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "-1")
 
@@ -699,7 +699,7 @@ internal class OppgaveServiceTest {
                     behandlesAvApplikasjon = BehandlesAvApplikasjon.EF_SAK,
                 )
             every { integrasjonerClient.oppdaterOppgave(oppgaveId, capture(oppgaveSlot)) } returns 123
-            every { søknadskvitteringService.hentSøknad(any()) } returns søknadOvergangsstønad()
+            every { søknadService.hentSøknad(any()) } returns søknadOvergangsstønad()
 
             oppgaveService.oppdaterOppgaveMedRiktigMappeId(oppgaveId, "-1")
 

--- a/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadServiceIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/service/SøknadServiceIntegrasjonTest.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.mottak.IntegrasjonSpringRunnerTest
 import no.nav.familie.ef.mottak.repository.DokumentasjonsbehovRepository
 import no.nav.familie.ef.mottak.repository.VedleggRepository
 import no.nav.familie.ef.mottak.repository.domain.EncryptedFile
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.service.Testdata.skjemaForArbeidssøker
 import no.nav.familie.ef.mottak.service.Testdata.søknadBarnetilsyn
 import no.nav.familie.ef.mottak.service.Testdata.søknadOvergangsstønad
@@ -32,9 +32,9 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.assertNotEquals
 
-internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunnerTest() {
+internal class SøknadServiceIntegrasjonTest : IntegrasjonSpringRunnerTest() {
     @Autowired
-    lateinit var søknadskvitteringService: SøknadskvitteringService
+    lateinit var søknadService: SøknadService
 
     @Autowired
     lateinit var vedleggRepository: VedleggRepository
@@ -44,36 +44,36 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
 
     @Test
     internal fun `lagre skjema for arbeidssøker`() {
-        val kvittering = søknadskvitteringService.mottaArbeidssøkerSkjema(skjemaForArbeidssøker)
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaArbeidssøkerSkjema(skjemaForArbeidssøker)
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat((søknad)).isNotNull
     }
 
     @Test
     internal fun `lagre skjema for søknad`() {
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, emptyList()))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, emptyList()))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
     }
 
     @Test
     internal fun `lagre skjema for søknad overgangsstønad med vedlegg`() {
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
     }
 
     @Test
     internal fun `lagre skjema for skolepenger`() {
-        val kvittering = søknadskvitteringService.mottaSøknadSkolepenger(SøknadMedVedlegg(søknadSkolepenger, emptyList()))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadSkolepenger(SøknadMedVedlegg(søknadSkolepenger, emptyList()))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
     }
 
     @Test
     internal fun `lagre skjema for søknad skolepenger med vedlegg`() {
-        val kvittering = søknadskvitteringService.mottaSøknadSkolepenger(SøknadMedVedlegg(søknadSkolepenger, vedlegg))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadSkolepenger(SøknadMedVedlegg(søknadSkolepenger, vedlegg))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
     }
 
@@ -89,9 +89,9 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
             søknadOvergangsstønad.copy(
                 barn = Søknadsfelt("Barn", barnFødtIDag),
             )
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarnFødtIDag, vedlegg))
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarnFødtIDag, vedlegg))
 
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
         assertThat(søknad.behandleINySaksbehandling).isTrue
     }
@@ -111,9 +111,9 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
             søknadOvergangsstønad.copy(
                 barn = Søknadsfelt("Barn", listOf(barnFødtforLengeSiden, barnFødtIDag)),
             )
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarnFødtIDag, vedlegg))
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarnFødtIDag, vedlegg))
 
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
         assertThat(søknad.behandleINySaksbehandling).isTrue
     }
@@ -133,16 +133,16 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
             søknadOvergangsstønad.copy(
                 barn = Søknadsfelt("Barn", barn1mnd),
             )
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarn1mnd, vedlegg))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadMedBarn1mnd, vedlegg))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
         assertThat(søknad.behandleINySaksbehandling).isTrue
     }
 
     @Test
     internal fun `lagre skjema for søknad barnetilsyn`() {
-        val kvittering = søknadskvitteringService.mottaSøknadBarnetilsyn(SøknadMedVedlegg(søknadBarnetilsyn, emptyList()))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
+        val kvittering = søknadService.mottaSøknadBarnetilsyn(SøknadMedVedlegg(søknadBarnetilsyn, emptyList()))
+        val søknad = søknadService.hentSøknad(kvittering.id)
         assertThat(søknad).isNotNull
     }
 
@@ -151,8 +151,8 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
         val dokumentasjonsbehov = listOf(Dokumentasjonsbehov("label", "id", false, emptyList()))
         val søknad = søknadOvergangsstønad
         val kvittering =
-            søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknad, emptyList(), dokumentasjonsbehov))
-        val dokumentasjonsbehovDto = søknadskvitteringService.hentDokumentasjonsbehovForSøknad(søknadskvitteringService.hentSøknad(kvittering.id))
+            søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknad, emptyList(), dokumentasjonsbehov))
+        val dokumentasjonsbehovDto = søknadService.hentDokumentasjonsbehovForSøknad(søknadService.hentSøknad(kvittering.id))
 
         assertThat(dokumentasjonsbehovDto.personIdent).isEqualTo(søknad.personalia.verdi.fødselsnummer.verdi.verdi)
         assertThat(dokumentasjonsbehovDto.dokumentasjonsbehov).hasSize(1)
@@ -163,33 +163,33 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
 
     @Test
     fun `reduserSøknad sletter søknadPdf, dokumentasjonsbehov og vedlegg for gitt søknadId`() {
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
-        val søknadFørReduksjon = søknadskvitteringService.hentSøknad(kvittering.id)
-        søknadskvitteringService.oppdaterSøknad(søknadFørReduksjon.copy(søknadPdf = EncryptedFile(ByteArray(20)), journalpostId = "321"))
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
+        val søknadFørReduksjon = søknadService.hentSøknad(kvittering.id)
+        søknadService.oppdaterSøknad(søknadFørReduksjon.copy(søknadPdf = EncryptedFile(ByteArray(20)), journalpostId = "321"))
 
-        søknadskvitteringService.reduserSøknad(søknadFørReduksjon.id)
+        søknadService.reduserSøknad(søknadFørReduksjon.id)
 
-        val søknad = søknadskvitteringService.hentSøknad(søknadFørReduksjon.id)
+        val søknad = søknadService.hentSøknad(søknadFørReduksjon.id)
         assertThat(dokumentasjonsbehovRepository.findByIdOrNull(søknad.id)).isNull()
         assertThat(vedleggRepository.findBySøknadId(søknad.id)).isEmpty()
     }
 
     @Test
     fun `slettSøknad sletter søknad for gitt søknadId`() {
-        val kvittering = søknadskvitteringService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
-        val søknad = søknadskvitteringService.hentSøknad(kvittering.id)
-        søknadskvitteringService.oppdaterSøknad(søknad.copy(journalpostId = "321"))
-        søknadskvitteringService.reduserSøknad(søknad.id)
+        val kvittering = søknadService.mottaSøknadOvergangsstønad(SøknadMedVedlegg(søknadOvergangsstønad, vedlegg))
+        val søknad = søknadService.hentSøknad(kvittering.id)
+        søknadService.oppdaterSøknad(søknad.copy(journalpostId = "321"))
+        søknadService.reduserSøknad(søknad.id)
 
-        søknadskvitteringService.slettSøknad(søknad.id)
+        søknadService.slettSøknad(søknad.id)
 
-        assertThrows<IllegalStateException> { (søknadskvitteringService.hentSøknad(søknad.id)) }
+        assertThrows<IllegalStateException> { (søknadService.hentSøknad(søknad.id)) }
     }
 
     @Test
     fun `skal returnere tom liste med innnsendte søknader for førstegangsøker`() {
         val personIdent = "03125462714"
-        val søknader = søknadskvitteringService.hentSistInnsendtSøknadPerStønad(personIdent)
+        val søknader = søknadService.hentSistInnsendtSøknadPerStønad(personIdent)
 
         assertThat(søknader.isEmpty())
     }
@@ -199,9 +199,9 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
         val personIdent = "03125462714"
         val søknadMedVedlegg = genererOvergangstønadSøknadMedVedlegg(LocalDateTime.now())
 
-        søknadskvitteringService.mottaSøknadOvergangsstønad(søknadMedVedlegg)
+        søknadService.mottaSøknadOvergangsstønad(søknadMedVedlegg)
 
-        val søknader = søknadskvitteringService.hentSistInnsendtSøknadPerStønad(personIdent)
+        val søknader = søknadService.hentSistInnsendtSøknadPerStønad(personIdent)
 
         assertThat(søknader).hasSize(1)
         assertThat(søknader.first { it.stønadType == StønadType.OVERGANGSSTØNAD })
@@ -215,9 +215,9 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
         val personIdent = "03125462714"
         val søknadMedVedlegg = genererOvergangstønadSøknadMedVedlegg(DatoUtil.dagensDatoMedTid())
 
-        søknadskvitteringService.mottaSøknadOvergangsstønad(søknadMedVedlegg)
+        søknadService.mottaSøknadOvergangsstønad(søknadMedVedlegg)
 
-        val søknader = søknadskvitteringService.hentSistInnsendtSøknadPerStønad(personIdent)
+        val søknader = søknadService.hentSistInnsendtSøknadPerStønad(personIdent)
 
         assertThat(søknader).isEmpty()
         unmockkObject(DatoUtil)
@@ -230,10 +230,10 @@ internal class SøknadskvitteringServiceIntegrasjonTest : IntegrasjonSpringRunne
         val tidligereSøknad = genererOvergangstønadSøknadMedVedlegg(LocalDateTime.now().minusDays(7))
         val nyesteSøknad = genererOvergangstønadSøknadMedVedlegg(LocalDateTime.now())
 
-        søknadskvitteringService.mottaSøknadOvergangsstønad(tidligereSøknad)
-        søknadskvitteringService.mottaSøknadOvergangsstønad(nyesteSøknad)
+        søknadService.mottaSøknadOvergangsstønad(tidligereSøknad)
+        søknadService.mottaSøknadOvergangsstønad(nyesteSøknad)
 
-        val søknader = søknadskvitteringService.hentSistInnsendtSøknadPerStønad(personIdent)
+        val søknader = søknadService.hentSistInnsendtSøknadPerStønad(personIdent)
 
         val nyesteSøknadDato = søknader.first().søknadsdato
         val tidligereSøknadDato =

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/AutomatiskJournalførTaskTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.AutomatiskJournalføringService
 import no.nav.familie.ef.mottak.service.MappeService
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -23,7 +23,7 @@ import java.util.Properties
 
 internal class AutomatiskJournalførTaskTest {
     val automatiskJournalføringService: AutomatiskJournalføringService = mockk()
-    val søknadskvitteringService: SøknadskvitteringService = mockk()
+    val søknadService: SøknadService = mockk()
     val taskService: TaskService = mockk()
     val integrasjonerClient: IntegrasjonerClient = mockk(relaxed = true)
     val mappeService: MappeService = mockk(relaxed = true)
@@ -32,7 +32,7 @@ internal class AutomatiskJournalførTaskTest {
         AutomatiskJournalførTask(
             taskService = taskService,
             automatiskJournalføringService = automatiskJournalføringService,
-            søknadskvitteringService = søknadskvitteringService,
+            søknadService = søknadService,
             integrasjonerClient = integrasjonerClient,
             mappeService = mappeService,
         )
@@ -55,7 +55,7 @@ internal class AutomatiskJournalførTaskTest {
     @BeforeEach
     internal fun setUp() {
         every {
-            søknadskvitteringService.hentSøknad(overgangsstønadSøknadId)
+            søknadService.hentSøknad(overgangsstønadSøknadId)
         } returns
             Søknad(
                 søknadJson = EncryptedString(""),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/FerdigstillJournalføringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/FerdigstillJournalføringTaskTest.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.IntegrasjonerClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.ArkiveringService
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.util.FnrGenerator
@@ -17,9 +17,9 @@ import java.util.Properties
 
 internal class FerdigstillJournalføringTaskTest {
     private val integrasjonerClient: IntegrasjonerClient = mockk()
-    private val søknadskvitteringService: SøknadskvitteringService = mockk()
+    private val søknadService: SøknadService = mockk()
     private val arkiveringService: ArkiveringService =
-        ArkiveringService(integrasjonerClient, søknadskvitteringService, mockk(), mockk(), mockk())
+        ArkiveringService(integrasjonerClient, søknadService, mockk(), mockk(), mockk())
     private val ferdigstillJournalføringTask = FerdigstillJournalføringTask(arkiveringService)
 
     @Test
@@ -30,7 +30,7 @@ internal class FerdigstillJournalføringTaskTest {
         val enhetSlot = slot<String>()
 
         every {
-            søknadskvitteringService.hentSøknad("123L")
+            søknadService.hentSøknad("123L")
         } returns
             Søknad(
                 søknadJson = EncryptedString(""),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendDokumentasjonsbehovMeldingTilDittNavTaskTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ef.mottak.config.EttersendingConfig
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.kontrakter.ef.søknad.Dokument
 import no.nav.familie.kontrakter.ef.søknad.Dokumentasjonsbehov
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
@@ -25,7 +25,7 @@ import java.util.UUID
 internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
     private lateinit var sendDokumentasjonsbehovMeldingTilDittNavTask: SendDokumentasjonsbehovMeldingTilDittNavTask
     private lateinit var dittNavKafkaProducer: DittNavKafkaProducer
-    private lateinit var søknadskvitteringService: SøknadskvitteringService
+    private lateinit var søknadService: SøknadService
     private lateinit var taskService: TaskService
     private lateinit var ettersendingConfig: EttersendingConfig
 
@@ -34,13 +34,13 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
     @BeforeEach
     internal fun setUp() {
         dittNavKafkaProducer = mockk(relaxed = true)
-        søknadskvitteringService = mockk()
+        søknadService = mockk()
         taskService = mockk(relaxed = true)
         ettersendingConfig = mockk()
         sendDokumentasjonsbehovMeldingTilDittNavTask =
             SendDokumentasjonsbehovMeldingTilDittNavTask(
                 dittNavKafkaProducer,
-                søknadskvitteringService,
+                søknadService,
                 taskService,
                 ettersendingConfig,
             )
@@ -59,8 +59,8 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
         sendDokumentasjonsbehovMeldingTilDittNavTask.doTask(Task("", SØKNAD_ID, properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any())
+            søknadService.hentSøknad(any())
+            søknadService.hentDokumentasjonsbehovForSøknad(any())
             taskService.save(any())
 
             dittNavKafkaProducer.sendBeskjedTilBruker(
@@ -126,10 +126,10 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
         sendDokumentasjonsbehovMeldingTilDittNavTask.doTask(Task("", SØKNAD_ID, properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
+            søknadService.hentSøknad(any())
         }
         verify(exactly = 0) {
-            søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any())
+            søknadService.hentDokumentasjonsbehovForSøknad(any())
         }
 
         verify(exactly = 0) {
@@ -169,12 +169,12 @@ internal class SendDokumentasjonsbehovMeldingTilDittNavTaskTest {
             error("Lagrer aldri dokumentasjonsbehov til arbeidssøker")
         }
 
-        every { søknadskvitteringService.hentDokumentasjonsbehovForSøknad(any()) } returns
+        every { søknadService.hentDokumentasjonsbehovForSøknad(any()) } returns
             DokumentasjonsbehovDto(dokumentasjonsbehov, LocalDateTime.now(), søknadType, FNR)
     }
 
     private fun mockSøknad(søknadType: SøknadType = SøknadType.OVERGANGSSTØNAD) {
-        every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
+        every { søknadService.hentSøknad(SØKNAD_ID) } returns
             Søknad(
                 id = SØKNAD_ID,
                 søknadJson = EncryptedString(""),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ef.mottak.repository.domain.Ettersending
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
 import no.nav.familie.ef.mottak.service.EttersendingService
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.task.SendPåminnelseOmDokumentasjonsbehovTilDittNavTask
 import no.nav.familie.ef.mottak.util.lagMeldingPåminnelseManglerDokumentasjonsbehov
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
@@ -28,7 +28,7 @@ import java.util.UUID
 internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
     private lateinit var sendPåminnelseOmDokumentasjonsbehovTilDittNavTask: SendPåminnelseOmDokumentasjonsbehovTilDittNavTask
     private lateinit var dittNavKafkaProducer: DittNavKafkaProducer
-    private lateinit var søknadskvitteringService: SøknadskvitteringService
+    private lateinit var søknadService: SøknadService
     private lateinit var ettersendingService: EttersendingService
     private lateinit var ettersendingConfig: EttersendingConfig
     private lateinit var saksbehandlingClient: SaksbehandlingClient
@@ -38,14 +38,14 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
     @BeforeEach
     internal fun setUp() {
         dittNavKafkaProducer = mockk(relaxed = true)
-        søknadskvitteringService = mockk()
+        søknadService = mockk()
         ettersendingService = mockk()
         ettersendingConfig = mockk()
         saksbehandlingClient = mockk()
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask =
             SendPåminnelseOmDokumentasjonsbehovTilDittNavTask(
                 dittNavKafkaProducer,
-                søknadskvitteringService,
+                søknadService,
                 ettersendingService,
                 ettersendingConfig,
                 saksbehandlingClient,
@@ -67,8 +67,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
             dittNavKafkaProducer.sendBeskjedTilBruker(
@@ -96,8 +96,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
             dittNavKafkaProducer wasNot called
         }
@@ -114,8 +114,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
             dittNavKafkaProducer wasNot called
         }
@@ -138,8 +138,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
             dittNavKafkaProducer.sendBeskjedTilBruker(
@@ -169,8 +169,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
 
             dittNavKafkaProducer.sendBeskjedTilBruker(
@@ -194,8 +194,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
             dittNavKafkaProducer wasNot called
         }
@@ -212,8 +212,8 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
         sendPåminnelseOmDokumentasjonsbehovTilDittNavTask.doTask(Task("", søknadIds.first(), properties))
 
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
-            søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR))
+            søknadService.hentSøknad(any())
+            søknadService.hentSøknaderForPerson(PersonIdent(FNR))
             ettersendingService.hentEttersendingerForPerson(PersonIdent(FNR))
             dittNavKafkaProducer wasNot called
         }
@@ -232,7 +232,7 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
     )
 
     private fun mockHentSøknad(søknadData: SøknadData) {
-        every { søknadskvitteringService.hentSøknad(søknadIds.first()) } returns
+        every { søknadService.hentSøknad(søknadIds.first()) } returns
             søknad(
                 søknadData.id,
                 søknadData.dokumentType,
@@ -241,7 +241,7 @@ internal class SendPåminnelseOmDokumentasjonsbehovTilDittNavTaskTest {
     }
 
     private fun mockHentSøknaderForPerson(søknadData: List<SøknadData>) {
-        every { søknadskvitteringService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
+        every { søknadService.hentSøknaderForPerson(PersonIdent(FNR)) } returns
             listOf(søknad(søknadData.first().id, søknadData.first().dokumentType, søknadData.first().opprettetTid)) +
             søknadData.takeLast(søknadData.size - 1).map { søknad(it.id, it.dokumentType, it.opprettetTid) }
     }

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/SendSøknadMottattTilDittNavTaskTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.repository.domain.Søknad
 import no.nav.familie.ef.mottak.service.DittNavKafkaProducer
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.ef.mottak.task.SendDokumentasjonsbehovMeldingTilDittNavTask
 import no.nav.familie.ef.mottak.task.SendSøknadMottattTilDittNavTask
 import no.nav.familie.kontrakter.ef.søknad.SøknadType
@@ -19,15 +19,15 @@ import java.util.UUID
 internal class SendSøknadMottattTilDittNavTaskTest {
     private lateinit var sendSøknadMottattTilDittNavTask: SendSøknadMottattTilDittNavTask
     private lateinit var dittNavKafkaProducer: DittNavKafkaProducer
-    private lateinit var søknadskvitteringService: SøknadskvitteringService
+    private lateinit var søknadService: SøknadService
     private lateinit var task: Task
 
     @BeforeEach
     internal fun setUp() {
         dittNavKafkaProducer = mockk(relaxed = true)
-        søknadskvitteringService = mockk()
+        søknadService = mockk()
         sendSøknadMottattTilDittNavTask =
-            SendSøknadMottattTilDittNavTask(dittNavKafkaProducer, søknadskvitteringService)
+            SendSøknadMottattTilDittNavTask(dittNavKafkaProducer, søknadService)
         val properties = Properties().apply { this["eventId"] = UUID.fromString(EVENT_ID) }
         task =
             Task(
@@ -67,7 +67,7 @@ internal class SendSøknadMottattTilDittNavTaskTest {
 
     private fun verifiserForventetKallMed(forventetTekst: String) {
         verify(exactly = 1) {
-            søknadskvitteringService.hentSøknad(any())
+            søknadService.hentSøknad(any())
 
             dittNavKafkaProducer.sendBeskjedTilBruker(
                 personIdent = FNR,
@@ -78,7 +78,7 @@ internal class SendSøknadMottattTilDittNavTaskTest {
     }
 
     private fun mockSøknad(søknadType: SøknadType) {
-        every { søknadskvitteringService.hentSøknad(SØKNAD_ID) } returns
+        every { søknadService.hentSøknad(SØKNAD_ID) } returns
             Søknad(
                 id = SØKNAD_ID,
                 søknadJson = EncryptedString(""),

--- a/src/test/kotlin/no/nav/familie/ef/mottak/task/VelgAutomatiskEllerManuellFlytTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/mottak/task/VelgAutomatiskEllerManuellFlytTaskTest.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ef.mottak.config.DOKUMENTTYPE_SKJEMA_ARBEIDSSØKER
 import no.nav.familie.ef.mottak.encryption.EncryptedString
 import no.nav.familie.ef.mottak.integration.SaksbehandlingClient
 import no.nav.familie.ef.mottak.repository.domain.Søknad
-import no.nav.familie.ef.mottak.service.SøknadskvitteringService
+import no.nav.familie.ef.mottak.service.SøknadService
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.util.FnrGenerator
@@ -20,9 +20,9 @@ import java.util.Properties
 internal class VelgAutomatiskEllerManuellFlytTaskTest {
     private val taskService: TaskService = mockk()
     private val saksbehandlingClient: SaksbehandlingClient = mockk()
-    private val søknadskvitteringService: SøknadskvitteringService = mockk()
+    private val søknadService: SøknadService = mockk()
     private val velgAutomatiskEllerManuellFlytTask =
-        VelgAutomatiskEllerManuellFlytTask(taskService, søknadskvitteringService, saksbehandlingClient)
+        VelgAutomatiskEllerManuellFlytTask(taskService, søknadService, saksbehandlingClient)
 
     private val arbeidssøkerSkjemaId = "999L"
     private val overgangsstønadSøknadId = "123L"
@@ -30,7 +30,7 @@ internal class VelgAutomatiskEllerManuellFlytTaskTest {
     @BeforeEach
     internal fun setUp() {
         every {
-            søknadskvitteringService.hentSøknad(overgangsstønadSøknadId)
+            søknadService.hentSøknad(overgangsstønadSøknadId)
         } returns
             Søknad(
                 søknadJson = EncryptedString(""),
@@ -39,7 +39,7 @@ internal class VelgAutomatiskEllerManuellFlytTaskTest {
                 fnr = FnrGenerator.generer(),
             )
         every {
-            søknadskvitteringService.hentSøknad(arbeidssøkerSkjemaId)
+            søknadService.hentSøknad(arbeidssøkerSkjemaId)
         } returns
             Søknad(
                 søknadJson = EncryptedString(""),


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24467)

- renamer fra SøknadskvitteringController til SøknadController
- renamer fra SøknadskvitteringService til SøknadService
- fjernert "søknadskvittering" fra URI til controller