### PR TITLE
Vil øke minnet til vi får slettet kryptert kolonne med json i soknad.…

### DIFF
--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -24,7 +24,7 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       memory: 1Gi
       cpu: 100m


### PR DESCRIPTION
… Vil unngå OO feil da vi bruker mer minne når vi har både klartekst og kryptert versjoon av samme json.