### PR TITLE
Bumper kontrakter til en versjon hvor get ikke finnes på fødselsnumme…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20260526102747_ed05f71</prosessering.version>
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->
         <confluent.version>8.2.0</confluent.version>
-        <kontrakter.version>4.0_20260505124916_025d466</kontrakter.version>
+        <kontrakter.version>4.0_20260609150326_d2259dc</kontrakter.version>
         <token-validation.version>6.0.5</token-validation.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
         <start-class>no.nav.familie.ef.mottak.ApplicationKt</start-class>


### PR DESCRIPTION
…r. Da det har kommet feil i prod på serialsering av fødselsnumer fordi jackson tar i bruk getter.